### PR TITLE
Add each user's slug to request parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Update a signle task.
 task_id = client.update_image_classification_task(
     task_id="YOUR_TASK_ID",
     status="approved",
+    assignee="USER_SLUG",
     tags=["tag1", "tag2"]
     attributes=[
         {
@@ -588,6 +589,7 @@ Update a signle task.
 task_id = client.update_video_classification_task(
     task_id="YOUR_TASK_ID",
     status="approved",
+    assignee="USER_SLUG",
     tags=["tag1", "tag2"]
     attributes=[
         {

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -385,7 +385,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -432,7 +432,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -493,7 +493,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -542,7 +542,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -589,7 +589,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -626,7 +626,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -665,7 +665,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -704,7 +704,7 @@ class Client:
         if tags:
             payload["tags"] = tags
 
-        self._fill_assign_users(payload, **kwargs)
+        self.__fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -1215,7 +1215,7 @@ class Client:
         self.api.delete_request(endpoint)
 
     @staticmethod
-    def _fill_assign_users(payload: dict, **kwargs):
+    def __fill_assign_users(payload: dict, **kwargs):
         if "assignee" in kwargs:
             payload["assignee"] = kwargs.get("assignee")
         if "reviewer" in kwargs:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -349,6 +349,12 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single image task.
@@ -360,6 +366,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         annotations is a list of annotation to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/image"
         if not utils.is_image_supported_ext(file_path):
@@ -377,6 +389,19 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.post_request(endpoint, payload=payload)
 
     def create_image_classification_task(
@@ -388,6 +413,12 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single image classification task.
@@ -399,6 +430,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         attributes is a list of attribute to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/image/classification"
         if not utils.is_image_supported_ext(file_path):
@@ -414,6 +451,19 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.post_request(endpoint, payload=payload)
 
     def create_multi_image_task(
@@ -425,6 +475,12 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single multi image task.
@@ -436,6 +492,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         annotations is a list of annotation to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         if not os.path.isdir(folder_path):
             raise FastLabelInvalidException(
@@ -465,6 +527,19 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.post_request(endpoint, payload=payload)
 
     def create_video_task(
@@ -476,6 +551,12 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single video task.
@@ -487,6 +568,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         annotations is a list of annotation to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/video"
         if not utils.is_video_supported_ext(file_path):
@@ -504,6 +591,19 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.post_request(endpoint, payload=payload)
 
     def create_video_classification_task(
@@ -515,6 +615,12 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single video classification task.
@@ -526,6 +632,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         attributes is a list of attribute to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/video/classification"
         if not utils.is_video_supported_ext(file_path):
@@ -540,6 +652,19 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.post_request(endpoint, payload=payload)
 
     # Task Update
@@ -550,6 +675,12 @@ class Client:
         status: str = None,
         external_status: str = None,
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Update a single task.
@@ -558,6 +689,12 @@ class Client:
         status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined'. (Optional)
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         tags is a list of tag to be set. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/" + task_id
         payload = {}
@@ -567,6 +704,19 @@ class Client:
             payload["externalStatus"] = external_status
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.put_request(endpoint, payload=payload)
 
     def update_image_classification_task(
@@ -576,6 +726,12 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single image classification task.
@@ -585,6 +741,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         attributes is a list of attribute to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/image/classification/" + task_id
         payload = {}
@@ -596,6 +758,19 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.put_request(endpoint, payload=payload)
 
     def update_video_classification_task(
@@ -605,6 +780,12 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
+        assignee: str = None,
+        reviewer: str = None,
+        approver: str = None,
+        external_assignee: str = None,
+        external_reviewer: str = None,
+        external_approver: str = None,
     ) -> str:
         """
         Create a single video classification task.
@@ -614,6 +795,12 @@ class Client:
         external_status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
         attributes is a list of attribute to be set in advance. (Optional)
         tags is a list of tag to be set in advance. (Optional)
+        assignee is slug of assigned user. (Optional)
+        reviewer is slug of review user. (Optional)
+        approver is slug of approve user. (Optional)
+        external_assignee is slug of external assigned user. (Optional)
+        external_reviewer is slug of external review user. (Optional)
+        external_approver is slug of external approve user. (Optional)
         """
         endpoint = "tasks/video/classification/" + task_id
         payload = {}
@@ -625,6 +812,19 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
+        if assignee:
+            payload["assignee"] = assignee
+        if reviewer:
+            payload["reviewer"] = reviewer
+        if approver:
+            payload["approver"] = approver
+        if external_assignee:
+            payload["externalAssignee"] = external_assignee
+        if external_reviewer:
+            payload["externalReviewer"] = external_reviewer
+        if external_approver:
+            payload["externalApprover"] = external_approver
+
         return self.api.put_request(endpoint, payload=payload)
 
     # Task Delete
@@ -727,7 +927,7 @@ class Client:
         tasks = converters.to_pixel_coordinates(tasks)
         for task in tasks:
             self.__export_index_color_image(task=task, output_dir=output_dir, pallete=pallete, is_instance_segmentation=True)
-    
+
     def export_semantic_segmentation(self, tasks: list, output_dir: str = os.path.join("output", "semantic_segmentation"), pallete: List[int] = const.COLOR_PALETTE) -> None:
         """
         Convert tasks to index color semantic segmentation (PNG files).

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -349,12 +349,7 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs
     ) -> str:
         """
         Create a single image task.
@@ -389,18 +384,8 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -413,12 +398,7 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single image classification task.
@@ -451,18 +431,8 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -475,12 +445,7 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single multi image task.
@@ -527,18 +492,8 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -551,12 +506,7 @@ class Client:
         external_status: str = None,
         annotations: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single video task.
@@ -591,18 +541,8 @@ class Client:
             payload["annotations"] = annotations
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -615,12 +555,7 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single video classification task.
@@ -652,18 +587,8 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.post_request(endpoint, payload=payload)
 
@@ -675,12 +600,7 @@ class Client:
         status: str = None,
         external_status: str = None,
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Update a single task.
@@ -704,18 +624,8 @@ class Client:
             payload["externalStatus"] = external_status
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -726,12 +636,7 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single image classification task.
@@ -758,18 +663,8 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -780,12 +675,7 @@ class Client:
         external_status: str = None,
         attributes: list = [],
         tags: list = [],
-        assignee: str = None,
-        reviewer: str = None,
-        approver: str = None,
-        external_assignee: str = None,
-        external_reviewer: str = None,
-        external_approver: str = None,
+        **kwargs,
     ) -> str:
         """
         Create a single video classification task.
@@ -812,18 +702,8 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
-        if assignee:
-            payload["assignee"] = assignee
-        if reviewer:
-            payload["reviewer"] = reviewer
-        if approver:
-            payload["approver"] = approver
-        if external_assignee:
-            payload["externalAssignee"] = external_assignee
-        if external_reviewer:
-            payload["externalReviewer"] = external_reviewer
-        if external_approver:
-            payload["externalApprover"] = external_approver
+
+        self._fill_assign_users(payload, **kwargs)
 
         return self.api.put_request(endpoint, payload=payload)
 
@@ -1320,3 +1200,18 @@ class Client:
         """
         endpoint = "projects/" + project_id
         self.api.delete_request(endpoint)
+
+    @staticmethod
+    def _fill_assign_users(payload: dict, **kwargs):
+        if "assignee" in kwargs:
+            payload["assignee"] = kwargs.get("assignee")
+        if "reviewer" in kwargs:
+            payload["reviewer"] = kwargs.get("reviewer")
+        if "approver" in kwargs:
+            payload["approver"] = kwargs.get("approver")
+        if "external_assignee" in kwargs:
+            payload["externalAssignee"] = kwargs.get("external_assignee")
+        if "external_reviewer" in kwargs:
+            payload["externalReviewer"] = kwargs.get("external_reviewer")
+        if "external_approver" in kwargs:
+            payload["externalApprover"] = kwargs.get("external_approver")

--- a/fastlabel/utils.py
+++ b/fastlabel/utils.py
@@ -1,5 +1,6 @@
 import os
 import base64
+from typing import List
 
 
 def base64_encode(file_path: str) -> str:
@@ -23,7 +24,7 @@ def get_basename(file_path: str) -> str:
     return os.path.splitext(file_path)[0]
 
 
-def reverse_points(points: list[int]) -> list[int]:
+def reverse_points(points: List[int]) -> List[int]:
     """
     e.g.)
     [4, 5, 4, 9, 8, 9, 8, 5, 4, 5] => [4, 5, 8, 5, 8, 9, 4, 9, 4, 5]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.25.1
 numpy==1.20.2
 geojson==2.5.0
 xmltodict==0.12.0
-Pillow==8.3.1
+Pillow==8.3.2
 opencv-python==4.5.3.56

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", encoding="utf-8") as file:
 
 setuptools.setup(
     name="fastlabel",
-    version="0.11.4",
+    version="0.11.5",
     author="eisuke-ueta",
     author_email="eisuke.ueta@fastlabel.ai",
     description="The official Python SDK for FastLabel API, the Data Platform for AI",


### PR DESCRIPTION
### 対象Issue
https://github.com/fastlabel/fastlabel-application/issues/654

### 変更点
* 以下のAPIで、`assignee`, `reviewer`, `approver`, `external_assignee`, `external_reviewer`, `external_approver` を指定できるように修正
  * create_image_task
  * create_image_classification_task
  * create_multi_image_task
  * create_video_task
  * create_video_classification_task
  * update_task
  * update_image_classification_task
  * update_video_classification_task