### PR TITLE
fix coco keypoints with points short

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -157,6 +157,7 @@ def __get_coco_annotation_keypoints(keypoints: list) -> list:
         value = keypoint["value"]
         if not value:
             coco_annotation_keypoints.extend([0, 0, 0])
+            continue
         # Adjust fastlabel data definition to coco format
         visibility = 2 if value[2] == 1 else 1
         coco_annotation_keypoints.extend([value[0], value[1], visibility])


### PR DESCRIPTION
骨格推定で設定されているポイントで、打たれていないものが存在すると出力ができない不具合の修正