### PR TITLE
fix coco supercategory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported following project types:
 - Image - Keypoint
 - Image - Line
 - Image - Segmentation
-- Image - Pose Estimation(not support Create Task)
+- Image - Pose Estimation
 - Image - All
 
 #### Create Task

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from curses import keyname
 from datetime import datetime
 from decimal import Decimal
 from typing import List
@@ -667,7 +666,7 @@ def execute_coco_to_fastlabel(coco: dict ,annotation_type:str) -> dict:
     coco_categories = {}
     coco_categories_keypoints={}
     for c in coco["categories"]:
-        coco_categories[c["id"]] = c["name"]
+        coco_categories[c["id"]] = c["supercategory"]
         coco_categories_keypoints[c["id"]] = c["keypoints"]
 
     coco_annotations = coco["annotations"]


### PR DESCRIPTION
convert_coco_to_fastlabelの関数の、アノテーションクラスのvalueをとっているところを修正。

画面からのインポートでは、アノテーションクラスの値はCOCOフォーマットの`supercategory`を参照している。

しかし、SDKのコンバーターでは、アノテーションクラスの値がCOCOフォーマットの"name"を参照する形になっていたので修正