### PR TITLE
remove Pillow version limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.25.1
 numpy==1.20.2
 geojson==2.5.0
 xmltodict==0.12.0
-Pillow==8.3.2
+Pillow>=8.3.2
 opencv-python==4.5.3.56


### PR DESCRIPTION
Pillow 8.3.2 is no longer compatible with latest pytorch.
see: https://github.com/pytorch/vision/pull/4939

I think it's preferable that the pip versioning is compatible with pytorch because it is used in many AI projects. 