### PR TITLE
add export image with annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,26 @@ Example when the project type is Image - Pose Estimation
 }
 ```
 
+#### Export Image With Annotations 
+
+Get tasks and export images with annotations.
+Only support the following image extension.
+
+- jpeg
+- jpg
+- png
+- tif
+- tiff
+- bmp
+
+
+```python
+tasks = client.get_image_tasks(project="YOUR_PROJECT_SLUG")
+client.export_image_with_annotations(
+    tasks=tasks, image_dir="IMAGE_DIR", output_dir="OUTPUT_DIR"
+)
+```
+
 #### Integrate Task
 
 This function is alpha version. It is subject to major changes in the future.

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2,7 +2,7 @@ import glob
 import json
 import os
 import re
-from logging import getLogger
+import logging
 from typing import List
 from concurrent.futures import ThreadPoolExecutor
 import cv2
@@ -11,6 +11,7 @@ import xmltodict
 from PIL import Image, ImageColor, ImageDraw
 from fastlabel import const, converters, utils
 from fastlabel.const import (
+    EXPORT_IMAGE_WITH_ANNOTATIONS_SUPPORTED_IMAGE_TYPES,
     KEYPOINT_MIN_STROKE_WIDTH,
     OPACITY_DARK,
     OPACITY_THIN,
@@ -22,7 +23,11 @@ from fastlabel.const import (
 from .api import Api
 from .exceptions import FastLabelInvalidException
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(levelname)s: %(message)s",
+)
 
 
 class Client:
@@ -2263,7 +2268,7 @@ class Client:
             try:
                 rgb = ImageColor.getcolor(task_annotation["color"], "RGB")
             except Exception as e:
-                print(e)
+                logger.info(e)
             if not rgb:
                 continue
             rgba_dark = rgb + (OPACITY_DARK,)
@@ -2379,7 +2384,7 @@ class Client:
                             task_annotation_keypoint_keypoint_color, "RGB"
                         )
                     except Exception as e:
-                        print(
+                        logger.info(
                             f"Invalid color: {task_annotation_keypoint_keypoint_color}, "
                             f"content_name: {task_annotation_keypoint_name}, {e}"
                         )
@@ -2476,8 +2481,8 @@ class Client:
         for target_file_candidate_path in target_file_candidate_paths:
             if not os.path.isfile(target_file_candidate_path):
                 continue
-            if not target_file_candidate_path.endswith(
-                (".jpeg", ".jpg", ".png", ".JPEG", ".JPG", ".PNG", ".tif", ".TIF")
+            if not target_file_candidate_path.lower().endswith(
+                EXPORT_IMAGE_WITH_ANNOTATIONS_SUPPORTED_IMAGE_TYPES
             ):
                 continue
             img_file_paths.append(target_file_candidate_path)
@@ -2496,7 +2501,7 @@ class Client:
                 None,
             )
             if not task:
-                print(f"not find task. filepath: {task_name}")
+                logger.info(f"Not find task. filepath: {task_name}")
                 continue
             img_file_path_task_list.append([img_file_path, task, output_dir])
 

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -185,6 +185,15 @@ KEYPOINT_MIN_STROKE_WIDTH = 2
 POSE_ESTIMATION_MIN_STROKE_WIDTH = 7
 SEPARATOER = "@@@@@"
 
+EXPORT_IMAGE_WITH_ANNOTATIONS_SUPPORTED_IMAGE_TYPES = (
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".bmp",
+)
+
 # under 512 MB. Actual size is 536870888 bytes, but to consider other attributes,
 # minus 888 bytes.
 # Because of V8's limitation, API only can accept the JSON string that length is

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -179,6 +179,12 @@ COLOR_PALETTE = [
     102,
 ]
 
+OPACITY_DARK = 200
+OPACITY_THIN = 50
+KEYPOINT_MIN_STROKE_WIDTH = 2
+POSE_ESTIMATION_MIN_STROKE_WIDTH = 7
+SEPARATOER = "@@@@@"
+
 # under 512 MB. Actual size is 536870888 bytes, but to consider other attributes,
 # minus 888 bytes.
 # Because of V8's limitation, API only can accept the JSON string that length is
@@ -203,6 +209,7 @@ class AnnotationType(Enum):
     polygon = "polygon"
     keypoint = "keypoint"
     line = "line"
+    circle = "circle"
     segmentation = "segmentation"
     classification = "classification"
     pose_estimation = "pose_estimation"


### PR DESCRIPTION
close # https://github.com/fastlabel/fastlabel-application/issues/2937
## 概要
SDKでアノテーション付き画像がエクスポートできるようにする。

## 画面
タスク画面
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/66105049/194535294-9bf525bb-0429-4eab-80a9-3509e3fec9e6.png">
SDKでエクスポートした画像
<img width="903" alt="image" src="https://user-images.githubusercontent.com/66105049/194535425-2650c3fa-8c1d-42a8-aa58-f22a4a6d4935.png">



## テスト
画像全てのプロジェクトでエクスポートした画像でアノテーション付き画像をつける

## 補足