### PR TITLE
fix: type

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2236,7 +2236,7 @@ class Client:
             cv_points.append((new_points[i * 2], new_points[i * 2 + 1]))
         return np.array(cv_points)
 
-    def __reverse_points(self, points: list[int]) -> list[int]:
+    def __reverse_points(self, points: List[int]) -> List[int]:
         """
         e.g.)
         [4, 5, 4, 9, 8, 9, 8, 5, 4, 5] => [4, 5, 8, 5, 8, 9, 4, 9, 4, 5]
@@ -2863,7 +2863,7 @@ class Client:
         self, 
         project: str,
         status: str = "registered",
-        tags: list[str] = [],
+        tags: List[str] = [],
         priority: int = 0,
     ) -> dict:
         """


### PR DESCRIPTION
python3.8以前の場合に型定義がlist[int]の様な場合エラーになるので`from typing import List` でインポートされた先頭が大文字のListを利用するように修正

エラーが起きるパターンは以下のように明示的に配列の中身の型まで定義している場合
- list[int]

以下の書き方は問題ない
- list
- List
- List[int]

dict、tupleでも同様の問題が発生するが、grepして確認した結果List以外でエラーになる書き方はなかった
