### PR TITLE
Fix POST response control without payload and Base URL can be changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2115,7 +2115,7 @@ Create a new dataset.
 ```python
 dataset = client.create_dataset(
     name="Japanese Dogs",
-    slug="japanese_dogs",
+    slug="japanese-dogs",
     type="image"
 )
 ```
@@ -2128,7 +2128,7 @@ See API docs for details.
 {
     'id': 'YOUR_DATASET_ID',
     'name': 'Japanese Dogs',
-    'slug': 'japanese_dogs',
+    'slug': 'japanese-dogs',
     'type': 'image',
     'createdAt': '2022-10-31T02:20:00.248Z',
     'updatedAt': '2022-10-31T02:20:00.248Z'
@@ -2164,7 +2164,7 @@ datasets = client.get_datasets(
 )
 ```
 
-If you wish to retrieve more than 1000 data sets, please refer to the Task [sample code](#get%20tasks).
+If you wish to retrieve more than 1000 data sets, please refer to the Task [sample code](#get-tasks).
 
 ### Update Dataset
 
@@ -2250,7 +2250,7 @@ dataset_objects = client.get_dataset_objects(
 )
 ```
 
-If you wish to retrieve more than 1000 data sets, please refer to the Task [sample code](#get%20tasks).
+If you wish to retrieve more than 1000 data sets, please refer to the Task [sample code](#get-tasks).
 
 ### Delete Dataset Object
 

--- a/fastlabel/api.py
+++ b/fastlabel/api.py
@@ -4,14 +4,15 @@ import requests
 
 from .exceptions import FastLabelException, FastLabelInvalidException
 
-FASTLABEL_ENDPOINT = "https://api.fastlabel.ai/v1/"
-
 
 class Api:
 
+    base_url = "https://api.fastlabel.ai/v1/"
     access_token = None
 
     def __init__(self):
+        if os.environ.get("FASTLABEL_API_URL"):
+            self.base_url = os.environ.get("FASTLABEL_API_URL")
         if not os.environ.get("FASTLABEL_ACCESS_TOKEN"):
             raise ValueError("FASTLABEL_ACCESS_TOKEN is not configured.")
         self.access_token = "Bearer " + os.environ.get("FASTLABEL_ACCESS_TOKEN")
@@ -27,7 +28,7 @@ class Api:
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
-        r = requests.get(FASTLABEL_ENDPOINT + endpoint, headers=headers, params=params)
+        r = requests.get(self.base_url + endpoint, headers=headers, params=params)
 
         if r.status_code == 200:
             return r.json()
@@ -52,9 +53,7 @@ class Api:
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
-        r = requests.delete(
-            FASTLABEL_ENDPOINT + endpoint, headers=headers, params=params
-        )
+        r = requests.delete(self.base_url + endpoint, headers=headers, params=params)
 
         if r.status_code != 204:
             try:
@@ -77,10 +76,12 @@ class Api:
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
-        r = requests.post(FASTLABEL_ENDPOINT + endpoint, json=payload, headers=headers)
+        r = requests.post(self.base_url + endpoint, json=payload, headers=headers)
 
         if r.status_code == 200:
             return r.json()
+        elif r.status_code == 204:
+            return
         else:
             try:
                 error = r.json()["message"]
@@ -102,7 +103,7 @@ class Api:
             "Content-Type": "application/json",
             "Authorization": self.access_token,
         }
-        r = requests.put(FASTLABEL_ENDPOINT + endpoint, json=payload, headers=headers)
+        r = requests.put(self.base_url + endpoint, json=payload, headers=headers)
 
         if r.status_code == 200:
             return r.json()


### PR DESCRIPTION
## 概要

戻りのペイロードがないPOSTレスポンスでAPI側が204を返却するための対策と、開発を行いやすくするために、実行時に環境変数でリクエスト先APIを変更できるようにします。

本題とは異なりますが、READMEの記述を修正しています。

## テスト

- Get, Delete, Post, Putの各操作で想定通りの結果となること


