### PR TITLE
Add task functions for PCD projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ _If you are using FastLabel prototype, please install version 0.2.2._
   - [Text Classification](#text-classification)
   - [Audio](#audio)
   - [Audio Classification](#audio-classification)
+  - [PCD](#pcd)
   - [Common](#common)
 - [Annotation](#annotation)
 - [Project](#project)
@@ -1341,6 +1342,160 @@ task_id = client.update_audio_classification_task(
 )
 ```
 
+### PCD
+
+Supported following project types:
+
+- PCD - Cuboid
+- PCD - Segmentation
+
+#### Create Task
+
+Create a new task.
+
+```python
+task_id = client.create_pcd_task(
+    project="YOUR_PROJECT_SLUG",
+    name="sample.pcd",
+    file_path="./sample.pcd"
+)
+```
+
+Create a new task with pre-defined annotations. (Class should be configured on your project in advance)
+
+Annotation Type: cuboid
+
+```python
+task_id = client.create_pcd_task(
+    project="YOUR_PROJECT_SLUG",
+    name="sample.pcd",
+    file_path="./sample.pcd",
+    annotations=[
+        {
+            "type": "cuboid",
+            "value": "car",
+            "points": [ # For cuboid, it is a 9-digit number.
+                1, # Coordinate X
+                2, # Coordinate Y
+                3, # Coordinate Z
+                1, # Rotation x
+                1, # Rotation Y
+                1, # Rotation Z
+                2, # Length X
+                2, # Length Y
+                2  # Length Z
+            ],
+        }
+    ],
+)
+```
+
+Annotation Type: segmentation
+
+```python
+task_id = client.create_pcd_task(
+    project="YOUR_PROJECT_SLUG",
+    name="sample.pcd",
+    file_path="./sample.pcd",
+    annotations=[
+        {
+            "type": "segmentation",
+            "value": "car",
+            "points": [1, 2, 3, 4, 5], # For segmentation, it is an arbitrary numeric array.
+        }
+    ],
+)
+```
+
+##### Limitation
+
+- You can upload up to a size of 30 MB.
+
+#### Find Task
+
+Find a single task.
+
+```python
+task = client.find_pcd_task(task_id="YOUR_TASK_ID")
+```
+
+Find a single task by name.
+
+```python
+tasks = client.find_pcd_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+```
+
+#### Get Tasks
+
+Get tasks. (Up to 1000 tasks)
+
+```python
+tasks = client.get_pcd_tasks(project="YOUR_PROJECT_SLUG")
+```
+
+#### Update Task
+
+Update a single task.
+
+```python
+task_id = client.update_pcd_task(
+    task_id="YOUR_TASK_ID",
+    status="approved",
+    assignee="USER_SLUG",
+    tags=["tag1", "tag2"],
+    annotations=[
+        {
+            "type": "cuboid",
+            "value": "car",
+            "points": [ # For cuboid, it is a 9-digit number.
+                1, # Coordinate X
+                2, # Coordinate Y
+                3, # Coordinate Z
+                1, # Rotation x
+                1, # Rotation Y
+                1, # Rotation Z
+                2, # Length X
+                2, # Length Y
+                2  # Length Z
+            ],
+        }
+    ],
+)
+```
+
+#### Response
+
+Example of a single PCD task object
+
+```python
+{
+    "id": "YOUR_TASK_ID",
+    "name": "sample.pcd",
+    "url": "YOUR_TASK_URL",
+    "status": "registered",
+    "externalStatus": "registered",
+    "tags": ["tag1", "tag2"],
+    "assignee": "ASSIGNEE_NAME",
+    "reviewer": "REVIEWER_NAME",
+    "approver": "APPROVER_NAME",
+    "externalAssignee": "EXTERNAL_ASSIGNEE_NAME",
+    "externalReviewer": "EXTERNAL_REVIEWER_NAME",
+    "externalApprover": "EXTERNAL_APPROVER_NAME",
+    "annotations": [
+        {
+            "attributes": [],
+            "color": "#b36d18",
+            "title": "Car",
+            "type": "segmentation",
+            "value": "car",
+            "points": [1, 2, 3, 1, 1, 1, 2, 2, 2],
+        }
+    ],
+    "createdAt": "2021-02-22T11:25:27.158Z",
+    "updatedAt": "2021-02-22T11:25:27.158Z"
+}
+```
+
 ### Common
 
 APIs for update and delete are same over all tasks.
@@ -1384,7 +1539,7 @@ Task creation from S3.
   - Text
 
 - To use it, you need to set the contents of the following link.
-  https://docs.fastlabel.ai/docs/integrations-aws-s3
+  <https://docs.fastlabel.ai/docs/integrations-aws-s3>
 
 - Setup AWS S3 properties
 

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -641,7 +641,7 @@ class Client:
         task_name: str = None,
         offset: int = None,
         limit: int = 100,
-    ) -> list[dict]:
+    ) -> list:
         """
         Returns a list of PCD tasks.
         Returns up to 1000 at a time, to get more,

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -226,6 +226,25 @@ class Client:
             return None
         return tasks[0]
 
+    def find_pcd_task(self, task_id: str) -> dict:
+        """
+        Find a single PCD task.
+        """
+        endpoint = "tasks/pcd/" + task_id
+        return self.api.get_request(endpoint)
+
+    def find_pcd_task_by_name(self, project: str, task_name: str) -> dict:
+        """
+        Find a single PCD task by name.
+
+        project is slug of your project (Required).
+        task_name is a task name (Required).
+        """
+        tasks = self.get_pcd_tasks(project=project, task_name=task_name)
+        if not tasks:
+            return None
+        return tasks[0]
+
     # Task Get
 
     def get_image_tasks(
@@ -598,6 +617,52 @@ class Client:
         limit is the max number to fetch (Optional).
         """
         endpoint = "tasks/audio/classification"
+        params = {"project": project}
+        if status:
+            params["status"] = status
+        if external_status:
+            params["externalStatus"] = external_status
+        if tags:
+            params["tags"] = tags
+        if task_name:
+            params["taskName"] = task_name
+        if offset:
+            params["offset"] = offset
+        if limit:
+            params["limit"] = limit
+        return self.api.get_request(endpoint, params=params)
+
+    def get_pcd_tasks(
+        self,
+        project: str,
+        status: str = None,
+        external_status: str = None,
+        tags: list = [],
+        task_name: str = None,
+        offset: int = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """
+        Returns a list of PCD tasks.
+        Returns up to 1000 at a time, to get more,
+        set offset as the starting position to fetch.
+
+        project is slug of your project (Required).
+        status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined'. (Optional)
+        external_status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined',
+        'customer_declined' (Optional).
+        tags is a list of tag (Optional).
+        task_name is a task name (Optional).
+        offset is the starting position number to fetch (Optional).
+        limit is the max number to fetch (Optional).
+        """
+        if limit > 1000:
+            raise FastLabelInvalidException(
+                "Limit must be less than or equal to 1000.", 422
+            )
+        endpoint = "tasks/pcd"
         params = {"project": project}
         if status:
             params["status"] = status
@@ -1159,6 +1224,59 @@ class Client:
 
         return self.api.post_request(endpoint, payload=payload)
 
+    def create_pcd_task(
+        self,
+        project: str,
+        name: str,
+        file_path: str,
+        status: str = None,
+        external_status: str = None,
+        annotations: list = [],
+        tags: list = [],
+        **kwargs,
+    ) -> str:
+        """
+        Create a single PCD task.
+
+        project is slug of your project (Required).
+        name is an unique identifier of task in your project (Required).
+        file_path is a path to data. Supported extensions are pcd only (Required).
+        status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back',
+        'approved', 'declined' (Optional).
+        external_status can be 'registered', 'completed', 'skipped', 'reviewed',
+        'sent_back', 'approved', 'declined',  'customer_declined' (Optional).
+        annotations is a list of annotation to be set in advance (Optional).
+        tags is a list of tag to be set in advance (Optional).
+        assignee is slug of assigned user (Optional).
+        reviewer is slug of review user (Optional).
+        approver is slug of approve user (Optional).
+        external_assignee is slug of external assigned user (Optional).
+        external_reviewer is slug of external review user (Optional).
+        external_approver is slug of external approve user (Optional).
+        """
+        endpoint = "tasks/pcd"
+        if not utils.is_pcd_supported_ext(file_path):
+            raise FastLabelInvalidException("Supported extensions are pcd only", 422)
+        if not utils.is_pcd_supported_size(file_path):
+            raise FastLabelInvalidException("Supported PCD size is under 30 MB.", 422)
+
+        file = utils.base64_encode(file_path)
+        payload = {"project": project, "name": name, "file": file}
+        if status:
+            payload["status"] = status
+        if external_status:
+            payload["externalStatus"] = external_status
+        if annotations:
+            for annotation in annotations:
+                annotation["content"] = name
+            payload["annotations"] = annotations
+        if tags:
+            payload["tags"] = tags
+
+        self.__fill_assign_users(payload, **kwargs)
+
+        return self.api.post_request(endpoint, payload=payload)
+
     # Task Update
 
     def update_task(
@@ -1572,6 +1690,51 @@ class Client:
             payload["attributes"] = attributes
         if tags:
             payload["tags"] = tags
+
+        self.__fill_assign_users(payload, **kwargs)
+
+        return self.api.put_request(endpoint, payload=payload)
+
+    def update_pcd_task(
+        self,
+        task_id: str,
+        status: str = None,
+        external_status: str = None,
+        tags: list = [],
+        annotations: List[dict] = [],
+        **kwargs,
+    ) -> str:
+        """
+        Update a single pcd task.
+
+        task_id is an id of the task (Required).
+        status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back',
+        'approved', 'declined' (Optional).
+        external_status can be 'registered', 'completed', 'skipped', 'reviewed',
+        'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
+        tags is a list of tag to be set (Optional).
+        annotations is a list of annotation to be set (Optional).
+        assignee is slug of assigned user (Optional).
+        reviewer is slug of review user (Optional).
+        approver is slug of approve user (Optional).
+        external_assignee is slug of external assigned user (Optional).
+        external_reviewer is slug of external review user (Optional).
+        external_approver is slug of external approve user (Optional).
+        """
+        endpoint = "tasks/pcd/" + task_id
+        payload = {}
+        if status:
+            payload["status"] = status
+        if external_status:
+            payload["externalStatus"] = external_status
+        if tags:
+            payload["tags"] = tags
+        if annotations:
+            for annotation in annotations:
+                # Since the content name is not passed in the sdk update api,
+                # the content will be filled on the server side.
+                annotation["content"] = ""
+            payload["annotations"] = annotations
 
         self.__fill_assign_users(payload, **kwargs)
 

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -212,6 +212,9 @@ SUPPORTED_TEXT_SIZE = 2 * math.pow(1024, 2)
 # API can accept under 120 MB
 SUPPORTED_AUDIO_SIZE = 120 * math.pow(1024, 2)
 
+# API can accept under 30 MB
+SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
+
 
 class AnnotationType(Enum):
     bbox = "bbox"

--- a/fastlabel/utils.py
+++ b/fastlabel/utils.py
@@ -30,6 +30,12 @@ def is_audio_supported_ext(file_path: str) -> bool:
     return file_path.lower().endswith((".mp3", ".wav", ".m4a"))
 
 
+def is_pcd_supported_ext(file_path: str) -> bool:
+    # .ply is not yet supported. To support it, modification of the API
+    # needs to be considered as well.
+    return file_path.lower().endswith((".pcd"))
+
+
 def is_image_supported_size(file_path: str) -> bool:
     return os.path.getsize(file_path) <= const.SUPPORTED_IMAGE_SIZE
 
@@ -44,6 +50,10 @@ def is_text_supported_size(file_path: str) -> bool:
 
 def is_audio_supported_size(file_path: str) -> bool:
     return os.path.getsize(file_path) <= const.SUPPORTED_AUDIO_SIZE
+
+
+def is_pcd_supported_size(file_path: str) -> bool:
+    return os.path.getsize(file_path) <= const.SUPPORTED_PCD_SIZE
 
 
 def is_json_ext(file_name: str) -> bool:


### PR DESCRIPTION
参照: https://github.com/fastlabel/fastlabel-application/issues/3264

PCDプロジェクトのタスクを操作できるように、取得、作成、更新の計5つの関数を追加します。

## 補足

- @ueno-k-work さんと相談の結果、.plyについては非対応としています。
  - 非対応の理由は、適切に対応しようとするとAPIやBatchの修正を検討する必要があり、工数が大きくなるため。
- 3段階ワークフローでの適切なデータの作成方法がわからなかったため、external_xxxの登録、更新のテストができていません。

## テスト

以下のタイプのプロジェクトに対して追加した関数をテストしました。

- 点群：直方体
- 点群：セグメンテーション
