### PR TITLE
Fix export of video task for coco, yolo, PascalVOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -2069,14 +2069,15 @@ Support the following annotation types.
 Get tasks and export as a [COCO format](https://cocodataset.org/#format-data) file.
 
 ```python
-tasks = client.get_image_tasks(project="YOUR_PROJECT_SLUG")
-client.export_coco(tasks)
+project_slug = "YOUR_PROJECT_SLUG"
+tasks = client.get_image_tasks(project=project_slug)
+client.export_coco(project=project_slug, tasks=tasks)
 ```
 
 Export with specifying output directory and file name.
 
 ```python
-client.export_coco(tasks=tasks, output_dir="YOUR_DIRECTROY", output_file_name="YOUR_FILE_NAME")
+client.export_coco(project="YOUR_PROJECT_SLUG", tasks=tasks, output_dir="YOUR_DIRECTROY", output_file_name="YOUR_FILE_NAME")
 ```
 
 If you would like to export pose estimation type annotations, please pass annotations.
@@ -2085,7 +2086,7 @@ If you would like to export pose estimation type annotations, please pass annota
 project_slug = "YOUR_PROJECT_SLUG"
 tasks = client.get_image_tasks(project=project_slug)
 annotations = client.get_annotations(project=project_slug)
-client.export_coco(tasks=tasks, annotations=annotations, output_dir="YOUR_DIRECTROY", output_file_name="YOUR_FILE_NAME")
+client.export_coco(project=project_slug, tasks=tasks, annotations=annotations, output_dir="YOUR_DIRECTROY", output_file_name="YOUR_FILE_NAME")
 ```
 
 ### FastLabel To YOLO
@@ -2098,8 +2099,9 @@ Support the following annotation types.
 Get tasks and export as YOLO format files.
 
 ```python
-tasks = client.get_image_tasks(project="YOUR_PROJECT_SLUG")
-client.export_yolo(tasks, output_dir="YOUR_DIRECTROY")
+project_slug = "YOUR_PROJECT_SLUG"
+tasks = client.get_image_tasks(project=project_slug)
+client.export_yolo(project=project_slug, tasks=tasks, output_dir="YOUR_DIRECTROY")
 ```
 
 Get tasks and export as YOLO format files with classes.txt
@@ -2110,7 +2112,7 @@ project_slug = "YOUR_PROJECT_SLUG"
 tasks = client.get_image_tasks(project=project_slug)
 annotations = client.get_annotations(project=project_slug)
 classes = list(map(lambda annotation: annotation["value"], annotations))
-client.export_yolo(tasks=tasks, classes=classes, output_dir="YOUR_DIRECTROY")
+client.export_yolo(project=project_slug, tasks=tasks, classes=classes, output_dir="YOUR_DIRECTROY")
 ```
 
 ### FastLabel To Pascal VOC
@@ -2123,8 +2125,9 @@ Support the following annotation types.
 Get tasks and export as Pascal VOC format files.
 
 ```python
-tasks = client.get_image_tasks(project="YOUR_PROJECT_SLUG")
-client.export_pascalvoc(tasks)
+project_slug = "YOUR_PROJECT_SLUG"
+tasks = client.get_image_tasks(project=project_slug)
+client.export_pascalvoc(project=project_slug, tasks=tasks)
 ```
 
 ### FastLabel To labelme
@@ -2387,7 +2390,6 @@ for image_file_path in glob.iglob(os.path.join(input_dataset_path, "**/**.jpg"),
 ```
 
 > Please check const.COLOR_PALLETE for index colors.
-
 
 ## Execute endpoint
 

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2138,8 +2138,10 @@ class Client:
             raise FastLabelInvalidException(
                 "Output file name must have a json extension", 422
             )
-        coco = converters.to_coco(tasks, annotations)
         os.makedirs(output_dir, exist_ok=True)
+        coco = converters.to_coco(
+            tasks=tasks, annotations=annotations, output_dir=output_dir
+        )
         file_path = os.path.join(output_dir, output_file_name)
         with open(file_path, "w") as f:
             json.dump(coco, f, indent=4, ensure_ascii=False)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2190,13 +2190,16 @@ class Client:
         tasks is a list of tasks (Required).
         output_dir is output directory(default: output/pascalvoc) (Optional).
         """
-        pascalvoc = converters.to_pascalvoc(tasks)
+        os.makedirs(output_dir, exist_ok=True)
+        pascalvoc = converters.to_pascalvoc(tasks=tasks, output_dir=output_dir)
         for voc in pascalvoc:
             file_name = voc["annotation"]["filename"]
             basename = utils.get_basename(file_name)
-            file_path = os.path.join(output_dir, basename + ".xml")
+            file_path = os.path.join(output_dir, "annotations", basename + ".xml")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
-            xml = xmltodict.unparse(voc, pretty=True, full_document=False)
+            xml = xmltodict.unparse(
+                voc, pretty=True, indent="    ", full_document=False
+            )
             with open(file_path, "w", encoding="utf8") as f:
                 f.write(xml)
 

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2162,7 +2162,10 @@ class Client:
         classes is a list of annotation values.  e.g. ['dog','bird'] (Optional).
         output_dir is output directory(default: output/yolo) (Optional).
         """
-        annos, categories = converters.to_yolo(tasks, classes)
+        os.makedirs(output_dir, exist_ok=True)
+        annos, categories = converters.to_yolo(
+            tasks=tasks, classes=classes, output_dir=output_dir
+        )
         for anno in annos:
             file_name = anno["filename"]
             basename = utils.get_basename(file_name)
@@ -2173,7 +2176,6 @@ class Client:
                     f.write(obj)
                     f.write("\n")
         classes_file_path = os.path.join(output_dir, "classes.txt")
-        os.makedirs(os.path.dirname(classes_file_path), exist_ok=True)
         with open(classes_file_path, "w", encoding="utf8") as f:
             for category in categories:
                 f.write(category["name"])

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2196,7 +2196,10 @@ class Client:
             file_path = os.path.join(output_dir, "annotations", basename + ".txt")
             os.makedirs(os.path.dirname(file_path), exist_ok=True)
             with open(file_path, "w", encoding="utf8") as f:
-                for obj in anno["object"]:
+                objects = anno.get("object")
+                if objects is None:
+                    continue
+                for obj in objects:
                     f.write(obj)
                     f.write("\n")
         classes_file_path = os.path.join(output_dir, "classes.txt")

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2120,6 +2120,7 @@ class Client:
 
     def export_coco(
         self,
+        project: str,
         tasks: list,
         annotations: list = [],
         output_dir: str = os.path.join("output", "coco"),
@@ -2129,6 +2130,7 @@ class Client:
         Convert tasks to COCO format and export as a file.
         If you pass annotations, you can export Pose Estimation type annotations.
 
+        project is slug of your project (Required).
         tasks is a list of tasks (Required).
         annotations is a list of annotations (Optional).
         output_dir is output directory(default: output/coco) (Optional).
@@ -2138,9 +2140,19 @@ class Client:
             raise FastLabelInvalidException(
                 "Output file name must have a json extension", 422
             )
+
+        project = self.find_project_by_slug(project)
+        if project is None:
+            raise FastLabelInvalidException(
+                "Project not found. Check the project slag.", 422
+            )
+
         os.makedirs(output_dir, exist_ok=True)
         coco = converters.to_coco(
-            tasks=tasks, annotations=annotations, output_dir=output_dir
+            project_type=project["type"],
+            tasks=tasks,
+            annotations=annotations,
+            output_dir=output_dir,
         )
         file_path = os.path.join(output_dir, output_file_name)
         with open(file_path, "w") as f:
@@ -2148,6 +2160,7 @@ class Client:
 
     def export_yolo(
         self,
+        project: str,
         tasks: list,
         classes: list = [],
         output_dir: str = os.path.join("output", "yolo"),
@@ -2158,13 +2171,24 @@ class Client:
         If not , classes.txt will be generated based on passed tasks .
         (Annotations never used in your project will not be exported.)
 
+        project is slug of your project (Required).
         tasks is a list of tasks (Required).
         classes is a list of annotation values.  e.g. ['dog','bird'] (Optional).
         output_dir is output directory(default: output/yolo) (Optional).
         """
+
+        project = self.find_project_by_slug(project)
+        if project is None:
+            raise FastLabelInvalidException(
+                "Project not found. Check the project slag.", 422
+            )
+
         os.makedirs(output_dir, exist_ok=True)
         annos, categories = converters.to_yolo(
-            tasks=tasks, classes=classes, output_dir=output_dir
+            project_type=project["type"],
+            tasks=tasks,
+            classes=classes,
+            output_dir=output_dir,
         )
         for anno in annos:
             file_name = anno["filename"]
@@ -2182,16 +2206,29 @@ class Client:
                 f.write("\n")
 
     def export_pascalvoc(
-        self, tasks: list, output_dir: str = os.path.join("output", "pascalvoc")
+        self,
+        project: str,
+        tasks: list,
+        output_dir: str = os.path.join("output", "pascalvoc"),
     ) -> None:
         """
         Convert tasks to Pascal VOC format as files.
 
+        project is slug of your project (Required).
         tasks is a list of tasks (Required).
         output_dir is output directory(default: output/pascalvoc) (Optional).
         """
+
+        project = self.find_project_by_slug(project)
+        if project is None:
+            raise FastLabelInvalidException(
+                "Project not found. Check the project slag.", 422
+            )
+
         os.makedirs(output_dir, exist_ok=True)
-        pascalvoc = converters.to_pascalvoc(tasks=tasks, output_dir=output_dir)
+        pascalvoc = converters.to_pascalvoc(
+            project_type=project["type"], tasks=tasks, output_dir=output_dir
+        )
         for voc in pascalvoc:
             file_name = voc["annotation"]["filename"]
             basename = utils.get_basename(file_name)

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -85,7 +85,8 @@ def to_coco(tasks: list, output_dir: str, annotations: list = []) -> dict:
                 continue
 
             for image_annotation in sorted(
-                filtered_image_annotations, key=itemgetter("image_id", "category_id")
+                filtered_image_annotations,
+                key=itemgetter("image_id", "category_id", "area"),
             ):
                 annotation_id += 1
                 if not image_annotation:

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -17,12 +17,14 @@ import requests
 
 from fastlabel.const import AnnotationType
 from fastlabel.exceptions import FastLabelInvalidException
-from fastlabel.utils import is_video_supported_ext
+from fastlabel.utils import is_video_project_type
 
 # COCO
 
 
-def to_coco(tasks: list, output_dir: str, annotations: list = []) -> dict:
+def to_coco(
+    project_type: str, tasks: list, output_dir: str, annotations: list = []
+) -> dict:
     # Get categories
     categories = __get_coco_categories(tasks, annotations)
 
@@ -35,7 +37,7 @@ def to_coco(tasks: list, output_dir: str, annotations: list = []) -> dict:
         if task["height"] == 0 or task["width"] == 0:
             continue
 
-        if is_video_supported_ext(task["name"]):
+        if is_video_project_type(project_type):
             image_file_names = _export_image_files_for_video_task(
                 task, str((Path(output_dir) / "images").resolve())
             )
@@ -367,12 +369,17 @@ def __serialize(value: any) -> any:
 # YOLO
 
 
-def to_yolo(tasks: list, classes: list, output_dir: str) -> tuple:
+def to_yolo(project_type: str, tasks: list, classes: list, output_dir: str) -> tuple:
     if len(classes) == 0:
-        coco = to_coco(tasks=tasks, output_dir=output_dir)
+        coco = to_coco(project_type=project_type, tasks=tasks, output_dir=output_dir)
         return __coco2yolo(coco)
     else:
-        return __to_yolo(tasks=tasks, classes=classes, output_dir=output_dir)
+        return __to_yolo(
+            project_type=project_type,
+            tasks=tasks,
+            classes=classes,
+            output_dir=output_dir,
+        )
 
 
 def __coco2yolo(coco: dict) -> tuple:
@@ -420,13 +427,13 @@ def __coco2yolo(coco: dict) -> tuple:
     return annos, categories
 
 
-def __to_yolo(tasks: list, classes: list, output_dir: str) -> tuple:
+def __to_yolo(project_type: str, tasks: list, classes: list, output_dir: str) -> tuple:
     annos = []
     for task in tasks:
         if task["height"] == 0 or task["width"] == 0:
             continue
 
-        if is_video_supported_ext(task["name"]):
+        if is_video_project_type(project_type):
             image_file_names = _export_image_files_for_video_task(
                 task, str((Path(output_dir) / "images").resolve())
             )
@@ -521,13 +528,13 @@ def _truncate(n, decimals=0) -> float:
 # Pascal VOC
 
 
-def to_pascalvoc(tasks: list, output_dir: str) -> list:
+def to_pascalvoc(project_type: str, tasks: list, output_dir: str) -> list:
     pascalvoc = []
     for task in tasks:
         if task["height"] == 0 or task["width"] == 0:
             continue
 
-        if is_video_supported_ext(task["name"]):
+        if is_video_project_type(project_type):
             image_file_names = _export_image_files_for_video_task(
                 task, str((Path(output_dir) / "images").resolve())
             )

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -67,6 +67,7 @@ def to_coco(
                 return _get_annotation_points_for_image_annotation(anno)
 
         for index, task_image in enumerate(task_images, 1):
+            images.append(task_image)
             params = [
                 {
                     "annotation_value": annotation["value"],
@@ -95,8 +96,6 @@ def to_coco(
                     continue
                 image_annotation["id"] = annotation_id
                 annotations.append(image_annotation)
-
-            images.append(task_image)
 
     return {
         "images": images,
@@ -463,15 +462,16 @@ def __to_yolo(project_type: str, tasks: list, classes: list, output_dir: str) ->
                 image_anno_dicts = executor.map(__get_yolo_annotation, params)
 
             filtered_image_anno_dicts = list(filter(None, image_anno_dicts))
-            if len(filtered_image_anno_dicts) <= 0:
-                continue
 
-            image_anno_rows = [
-                " ".join(anno)
-                for anno in sorted(filtered_image_anno_dicts, key=itemgetter(0))
-                if anno
-            ]
-            anno = {"filename": image_file_name, "object": image_anno_rows}
+            anno = {"filename": image_file_name}
+
+            if len(filtered_image_anno_dicts) > 0:
+                anno["object"] = [
+                    " ".join(anno)
+                    for anno in sorted(filtered_image_anno_dicts, key=itemgetter(0))
+                    if anno
+                ]
+
             annos.append(anno)
 
     categories = map(lambda val: {"name": val}, sorted(classes))
@@ -563,8 +563,6 @@ def to_pascalvoc(project_type: str, tasks: list, output_dir: str) -> list:
                 pascalvoc_objs = executor.map(__get_pascalvoc_obj, params)
 
             filtered_pascalvoc_objs = list(filter(None, pascalvoc_objs))
-            if len(filtered_pascalvoc_objs) <= 0:
-                continue
 
             voc = {
                 "annotation": {
@@ -575,11 +573,14 @@ def to_pascalvoc(project_type: str, tasks: list, output_dir: str) -> list:
                         "depth": 3,
                     },
                     "segmented": 0,
-                    "object": list(
-                        sorted(filtered_pascalvoc_objs, key=itemgetter("name"))
-                    ),
                 }
             }
+
+            if len(filtered_pascalvoc_objs) > 0:
+                voc["annotation"]["object"] = list(
+                    sorted(filtered_pascalvoc_objs, key=itemgetter("name"))
+                )
+
             pascalvoc.append(voc)
     return pascalvoc
 

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -210,9 +210,8 @@ def __to_coco_annotation(data: dict) -> dict:
         AnnotationType.pose_estimation.value,
     ]:
         return None
-    if (
-        annotation_type != AnnotationType.pose_estimation.value
-        and (not points or len(points)) == 0
+    if annotation_type != AnnotationType.pose_estimation.value and (
+        not points or (len(points) == 0)
     ):
         return None
     if annotation_type == AnnotationType.bbox.value and (

--- a/fastlabel/utils.py
+++ b/fastlabel/utils.py
@@ -60,6 +60,10 @@ def is_pcd_supported_size(file_path: str) -> bool:
     return os.path.getsize(file_path) <= const.SUPPORTED_PCD_SIZE
 
 
+def is_video_project_type(project_type: str):
+    return type(project_type) is str and project_type.startswith("video_")
+
+
 def is_json_ext(file_name: str) -> bool:
     return file_name.lower().endswith(".json")
 
@@ -101,7 +105,8 @@ def sort_segmentation_points(points: List[int]) -> List[int]:
         if index == 0:
             continue
         if (
-            val[1] <= points_list[base_point_index][1] and val[0] <= points_list[base_point_index][0]
+            val[1] <= points_list[base_point_index][1]
+            and val[0] <= points_list[base_point_index][0]
         ):
             base_point_index = index
     new_points_array = np.vstack(


### PR DESCRIPTION
see: https://github.com/fastlabel/fastlabel-application/issues/3475

## 補足

WebのExportの動作と極力合わせていますが、一部異なります。
問題がありそうなら指摘をお願いします。~特に1。~

1. ~Webではアノテーションがないタスクでもアノテーションファイルを出力していますが、SDKではアノテーションがないタスクのアノテーションファイルは出力しません。~
    1. やはり問題ありそうだったので、修正しました。
1. Webでは出力対象アノテーションを指定した場合、対象アノテーションを含む動画タスクのフレーム別画像のみ出力されますが、SDKではすべての動画タスクのフレーム別画像が出力されます。
1. 同一フレームに同一アノテーションクラスで複数のアノテーションが指定されている場合、エクスポートしたアノテーションファイル内の記述順序が同一でない場合があります。ソートを指定して極力同一となるように対処していますが、完全に制御するにはAPI側とも合わせた修正が必要です。

また、いくつか既存のバグを発見し影響があるものは修正しましたが、以下は大きな影響がないため ueno さんと相談してコメントを残すのみとしています。

- アノテーションクラスが２つ以上あるプロジェクトをアノテーションを指定せずにCOCO形式でエクスポートしたとき、 `categories` の `color` がすべて同じになります。

## テスト

WebとSDKのぞれぞれで、動画タスクをCOCO、YOLO、PascalVOCでエクスポートし、Diffツールで差分を確認しました。