### PR TITLE
fix: resolve version conflicts between numpy and opencv-python dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.25.1
-numpy==1.20.2
+numpy>=1.21.2
 geojson==2.5.0
 xmltodict==0.12.0
 Pillow==9.0.1
-opencv-python==4.5.3.56
+opencv-python==4.7.0.72


### PR DESCRIPTION
## 問題の概要
- 直接指定しているnumpyのversion
- opencv-pythonが依存しているnumpyのversion

が食い違っており、結果として最新Versionのinstallができない状態が発生しています。  

※現状で pip install fastlabel をすると、opencv-pythonが存在しなかったVersion=0.9.7まで遡ってそれが自動的にinstallされる。

## 修正内容
これを解消するためにnumpyのVersionを固定ではなく「以上」で指定するようにします。
また、opencv-pythonが今のVersionのままの場合m1 MacでSDKを動かそうとした場合にcv2のエラーを吐く、という問題もあったため、opencv-pythonのバージョンも最新まで上げています。

## 修正後の確認
numpy, opencv-pythonを利用する export_coco 関数を実行し、正常に完了すること。
outputが意図した通りに出ることを確認しています。

## 参考
参考として、修正前にinstall時に出力されていたconflictエラーは以下です。
```
ERROR: Cannot install -r requirements.txt (line 6) and numpy==1.20.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.20.2
    opencv-python 4.5.3.56 depends on numpy>=1.21.0
```