### PR TITLE
fix readme to match sequential pcd limit 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1608,7 +1608,7 @@ task = client.find_sequential_pcd_task(project="YOUR_PROJECT_SLUG", task_name="Y
 
 #### Get Tasks
 
-Get tasks. (Up to 1000 tasks)
+Get tasks. (Up to 10 tasks)
 
 ```python
 tasks = client.get_sequential_pcd_tasks(project="YOUR_PROJECT_SLUG")


### PR DESCRIPTION
## 背景
- ```get_sequential_pcd_tasks```のlimitが10に修正されたが、README.mdの記載が1000のままだった

## 作業内容
- README.mdの```get_sequential_pcd_tasks```のlimitを10に修正