### PR TITLE
セグメンテーション画像出力のclassesデフォルト引数に追加しないように修正

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2518,16 +2518,15 @@ class Client:
             because they become the same color as the background(Optional).
         """
 
-        # Create target_classes they are not added to the default arguments.
-        target_classes = []
-        if len(classes) == 0:
+        # Copy classes to target_classes
+        # so that it is not added as a default argument.
+        target_classes = classes.copy()
+        if len(target_classes) == 0:
             for task in tasks:
                 for annotation in task["annotations"]:
                     target_classes.append(annotation["value"])
             target_classes = list(set(target_classes))
             target_classes.sort()
-        else:
-            target_classes.extend(classes)
 
         tasks = converters.to_pixel_coordinates(tasks)
         for task in tasks:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2519,13 +2519,15 @@ class Client:
         """
 
         # Create target_classes they are not added to the default arguments.
-        target_classes = classes
-        if len(target_classes) == 0:
+        target_classes = []
+        if len(classes) == 0:
             for task in tasks:
                 for annotation in task["annotations"]:
                     target_classes.append(annotation["value"])
             target_classes = list(set(target_classes))
             target_classes.sort()
+        else:
+            target_classes.extend(classes)
 
         tasks = converters.to_pixel_coordinates(tasks)
         for task in tasks:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2520,7 +2520,7 @@ class Client:
 
         # Create target_classes they are not added to the default arguments.
         target_classes = classes
-        if len(classes) == 0:
+        if len(target_classes) == 0:
             for task in tasks:
                 for annotation in task["annotations"]:
                     target_classes.append(annotation["value"])

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2517,12 +2517,15 @@ class Client:
             When start_index is 0, all pixels are assumed to have annotations
             because they become the same color as the background(Optional).
         """
+
+        # Create target_classes they are not added to the default arguments.
+        target_classes = classes
         if len(classes) == 0:
             for task in tasks:
                 for annotation in task["annotations"]:
-                    classes.append(annotation["value"])
-            classes = list(set(classes))
-            classes.sort()
+                    target_classes.append(annotation["value"])
+            target_classes = list(set(target_classes))
+            target_classes.sort()
 
         tasks = converters.to_pixel_coordinates(tasks)
         for task in tasks:
@@ -2531,7 +2534,7 @@ class Client:
                 output_dir=output_dir,
                 pallete=pallete,
                 is_instance_segmentation=False,
-                classes=classes,
+                classes=target_classes,
                 start_index=start_index,
             )
 


### PR DESCRIPTION
メソッドに対してclasses.append をするとデフォルト引数に追加してしまうようなので、
2回目にclassesに指定なして実行すると前回追加したclassesを元に出力してしまう不具合の修正。