### PR TITLE
[sdk][caddi要望]タスクの件数を取得するsdkの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1879,7 +1879,7 @@ Example of a single dicom task object
 
 ### Common
 
-APIs for update and delete are same over all tasks.
+APIs for update and delete and count are same over all tasks.
 
 #### Update Task
 
@@ -1914,6 +1914,15 @@ client.delete_task_annotations(task_id="YOUR_TASK_ID")
 
 ```python
 id_name_map = client.get_task_id_name_map(project="YOUR_PROJECT_SLUG")
+```
+
+#### Count Task
+```python
+task_count = client.count_tasks(
+    project="YOUR_PROJECT_SLUG",
+    status="approved", # status can be 'pending', 'registered', 'completed', 'skipped', 'reviewed' 'sent_back', 'approved', 'declined'
+    tags=["tag1", "tag2"] # up to 10 tags
+)
 ```
 
 #### Create Task from S3

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -292,6 +292,34 @@ class Client:
 
     # Task Get
 
+    def count_tasks(
+        self,
+        project: str,
+        status: str = None,
+        external_status: str = None,
+        tags: list = None,
+    ) -> int:
+        """
+        Returns task count.
+
+        project is slug of your project (Required).
+        status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined'. (Optional)
+        external_status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined',
+        'customer_declined' (Optional).
+        tags is a list of tag (Optional).
+        """
+        endpoint = "tasks/count"
+        params = {"project": project}
+        if status:
+            params["status"] = status
+        if external_status:
+            params["externalStatus"] = external_status
+        if tags:
+            params["tags"] = tags
+        return self.api.get_request(endpoint, params=params)
+
     def get_image_tasks(
         self,
         project: str,


### PR DESCRIPTION
## 概要
approveの件数をカウントした上で誰かにアサインすることを実現したい by caddi

## 動作確認
各パラメータを指定した時に、正常にタスクの件数がカウントされること


api側
https://github.com/fastlabel/fastlabel-application/pull/4081