### PR TITLE
python 3.7で動かない

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Literal
+from typing import List
 
 import cv2
 import numpy as np
@@ -943,7 +943,7 @@ class Client:
     def create_integrated_image_task(
         self,
         project: str,
-        storage_type: Literal["gcp"],
+        storage_type: str,
         file_path: str,
         status: str = None,
         external_status: str = None,


### PR DESCRIPTION
## 概要

ドキュメントには python 3.7 以降を要求しているが、3.7ではimport エラーが発生する。

```
>>> import fastlabel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/src/fastlabel/__init__.py", line 7, in <module>
    from typing import List, Literal
ImportError: cannot import name 'Literal' from 'typing' (/usr/local/lib/python3.7/typing.py)
```

## 原因

`Literal Types` は、python 3.8以降に導入された機能であるため
https://peps.python.org/pep-0586/

修正のあったコミット d1a84b7a
