### PR TITLE
Migration sequential

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ _If you are using FastLabel prototype, please install version 0.2.2._
 - [Task](#task)
   - [Image](#image)
   - [Image Classification](#image-classification)
-  - [Multi Image](#multi-image)
+  - [Sequential Image](#sequential-image)
   - [Video](#video)
   - [Video Classification](#video-classification)
   - [Text](#text)
@@ -122,7 +122,6 @@ task_id = client.create_image_task(
 
 - You can upload up to a size of 20 MB.
 
-
 #### Create Integrated Image Task
 
 Create a new task by integrated image.
@@ -142,7 +141,7 @@ Create a new task with pre-defined annotations. (Class should be configured on y
 task_id = client.create_image_task(
     project="YOUR_PROJECT_SLUG",
     file_path="<integrated-storage-dir>/sample.jpg",
-    storage_type="gcp",  
+    storage_type="gcp",
     annotations=[{
         "type": "bbox",
         "value": "annotation-value",
@@ -165,7 +164,6 @@ task_id = client.create_image_task(
 ##### Limitation
 
 - You can upload up to a size of 20 MB.
-
 
 #### Find Task
 
@@ -539,22 +537,22 @@ Example of a single image classification task object
 }
 ```
 
-### Multi Image
+### Sequential Image
 
 Supported following project types:
 
-- Multi Image - Bounding Box
-- Multi Image - Polygon
-- Multi Image - Keypoint
-- Multi Image - Line
-- Multi Image - Segmentation
+- Sequential Image - Bounding Box
+- Sequential Image - Polygon
+- Sequential Image - Keypoint
+- Sequential Image - Line
+- Sequential Image - Segmentation
 
 #### Create Task
 
 Create a new task.
 
 ```python
-task = client.create_multi_image_task(
+task = client.create_sequential_image_task(
     project="YOUR_PROJECT_SLUG",
     name="sample",
     folder_path="./sample",
@@ -596,13 +594,13 @@ task = client.create_multi_image_task(
 Find a single task.
 
 ```python
-task = client.find_multi_image_task(task_id="YOUR_TASK_ID")
+task = client.find_sequential_image_task(task_id="YOUR_TASK_ID")
 ```
 
 Find a single task by name.
 
 ```python
-tasks = client.find_multi_image_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+tasks = client.find_sequential_image_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
 ```
 
 #### Get Tasks
@@ -610,7 +608,7 @@ tasks = client.find_multi_image_task_by_name(project="YOUR_PROJECT_SLUG", task_n
 Get tasks.
 
 ```python
-tasks = client.get_multi_image_tasks(project="YOUR_PROJECT_SLUG")
+tasks = client.get_sequential_image_tasks(project="YOUR_PROJECT_SLUG")
 ```
 
 #### Update Task
@@ -618,7 +616,7 @@ tasks = client.get_multi_image_tasks(project="YOUR_PROJECT_SLUG")
 Update a single task.
 
 ```python
-task_id = client.update_multi_image_task(
+task_id = client.update_sequential_image_task(
     task_id="YOUR_TASK_ID",
     status="approved",
     assignee="USER_SLUG",
@@ -1950,6 +1948,7 @@ id_name_map = client.get_task_id_name_map(project="YOUR_PROJECT_SLUG")
 ```
 
 #### Count Task
+
 ```python
 task_count = client.count_tasks(
     project="YOUR_PROJECT_SLUG",

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -83,21 +83,21 @@ class Client:
             return None
         return tasks[0]
 
-    def find_multi_image_task(self, task_id: str) -> dict:
+    def find_sequential_image_task(self, task_id: str) -> dict:
         """
-        Find a single multi image task.
+        Find a single sequential image task.
         """
-        endpoint = "tasks/multi-image/" + task_id
+        endpoint = "tasks/sequential-image/" + task_id
         return self.api.get_request(endpoint)
 
-    def find_multi_image_task_by_name(self, project: str, task_name: str) -> dict:
+    def find_sequential_image_task_by_name(self, project: str, task_name: str) -> dict:
         """
-        Find a single multi image task by name.
+        Find a single sequential image task by name.
 
         project is slug of your project (Required).
         task_name is a task name (Required).
         """
-        tasks = self.get_multi_image_tasks(project=project, task_name=task_name)
+        tasks = self.get_sequential_image_tasks(project=project, task_name=task_name)
         if not tasks:
             return None
         return tasks[0]
@@ -406,7 +406,7 @@ class Client:
             params["limit"] = limit
         return self.api.get_request(endpoint, params=params)
 
-    def get_multi_image_tasks(
+    def get_sequential_image_tasks(
         self,
         project: str,
         status: str = None,
@@ -417,7 +417,7 @@ class Client:
         limit: int = 10,
     ) -> list:
         """
-        Returns a list of multi image tasks.
+        Returns a list of sequential image tasks.
         Returns up to 10 at a time, to get more, set offset as the starting position
         to fetch.
 
@@ -434,7 +434,7 @@ class Client:
             raise FastLabelInvalidException(
                 "Limit must be less than or equal to 10.", 422
             )
-        endpoint = "tasks/multi-image"
+        endpoint = "tasks/sequential-image"
         params = {"project": project}
         if status:
             params["status"] = status
@@ -1054,7 +1054,7 @@ class Client:
 
         return self.api.post_request(endpoint, payload=payload)
 
-    def create_multi_image_task(
+    def create_sequential_image_task(
         self,
         project: str,
         name: str,
@@ -1067,7 +1067,7 @@ class Client:
         **kwargs,
     ) -> str:
         """
-        Create a single multi image task.
+        Create a single sequential image task.
 
         project is slug of your project (Required).
         name is an unique identifier of task in your project (Required).
@@ -1096,7 +1096,7 @@ class Client:
         if not os.path.isdir(folder_path):
             raise FastLabelInvalidException("Folder does not exist.", 422)
 
-        endpoint = "tasks/multi-image"
+        endpoint = "tasks/sequential-image"
         file_paths = glob.glob(os.path.join(folder_path, "*"))
         if not file_paths:
             raise FastLabelInvalidException("Folder does not have any file.", 422)
@@ -1878,7 +1878,7 @@ class Client:
 
         return self.api.put_request(endpoint, payload=payload)
 
-    def update_multi_image_task(
+    def update_sequential_image_task(
         self,
         task_id: str,
         status: str = None,
@@ -1889,7 +1889,7 @@ class Client:
         **kwargs,
     ) -> str:
         """
-        Update a multi image task.
+        Update a sequential image task.
 
         task_id is an id of the task (Required).
         status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back',
@@ -1911,7 +1911,7 @@ class Client:
         external_reviewer is slug of external review user (Optional).
         external_approver is slug of external approve user (Optional).
         """
-        endpoint = "tasks/multi-image/" + task_id
+        endpoint = "tasks/sequential-image/" + task_id
         payload = {}
         if status:
             payload["status"] = status
@@ -3174,8 +3174,8 @@ class Client:
                     for points in region:
                         if count == 0:
                             cv_draw_points = self.__get_cv_draw_points(points)
-                            # For diagonal segmentation points, fillPoly cannot rendering cv_drawpoints, so convert
-                            # shape. When multiimage project can use only pixcel mode, remove it
+                            # For diagonal segmentation points, fillPoly cannot rendering cv_draw_points, so convert
+                            # shape. When sequential image project can use only pixel mode, remove it
                             converted_points = (
                                 np.array(cv_draw_points)
                                 .reshape((-1, 1, 2))
@@ -3639,9 +3639,9 @@ class Client:
         Create a project.
 
         type can be 'image_bbox', 'image_polygon', 'image_keypoint', 'image_line',
-        'image_segmentation', 'image_classification', 'image_all', 'multi_image_bbox',
-        'multi_image_polygon', 'multi_image_keypoint', 'multi_image_line',
-        'multi_image_segmentation', 'video_bbox',
+        'image_segmentation', 'image_classification', 'image_all', 'sequential_image_bbox',
+        'sequential_image_polygon', 'sequential_image_keypoint', 'sequential_image_line',
+        'sequential_image_segmentation', 'video_bbox',
         'video_single_classification' (Required).
         name is name of your project (Required).
         slug is slug of your project (Required).


### PR DESCRIPTION
連続画像プロジェクトをmulti_からsequential_に変更する修正対応
https://github.com/fastlabel/fastlabel-application/pull/4106
の対応と一緒に適応すること。
※後方互換性がなくなるので注意!

# テスト
create_sequential_image_task
find_sequential_image_task
get_sequential_image_task
update_sequential_image_task
の4つが実行できること

https://github.com/fastlabel/fastlabel-python-sdk/assets/114887968/91c4dd73-d1a1-4282-9199-a18c5e17f71f

