### PR TITLE
fix: remove annotation type from dataset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           files: '^.*\.py'
           types: [file]
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       -   id: isort
           files: '^.*\.py'

--- a/README.md
+++ b/README.md
@@ -2332,8 +2332,7 @@ Create a new dataset.
 dataset = client.create_dataset(
     name="Japanese Dogs",
     slug="japanese-dogs",
-    type="image",
-    annotation_type="image_bbox"
+    type="image"
 )
 ```
 

--- a/examples/create_dataset.py
+++ b/examples/create_dataset.py
@@ -5,9 +5,6 @@ import fastlabel
 client = fastlabel.Client()
 
 dataset = client.create_dataset(
-    name="Japanese Dogs",
-    slug="japanese-dogs",
-    type="video",
-    annotation_type="image_bbox",
+    name="Japanese Dogs", slug="japanese-dogs", type="video"
 )
 pprint(dataset)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -976,7 +976,11 @@ class Client:
                 "Supported extensions are png, jpg, jpeg.", 422
             )
 
-        payload = {"project": project, "filePath": file_path, "storageType": storage_type}
+        payload = {
+            "project": project,
+            "filePath": file_path,
+            "storageType": storage_type,
+        }
         if status:
             payload["status"] = status
         if external_status:
@@ -1551,13 +1555,10 @@ class Client:
         """
         endpoint = "tasks/dicom"
         if not utils.is_dicom_supported_ext(file_path):
-            raise FastLabelInvalidException(
-                "Supported extensions are zip.", 422
-            )
+            raise FastLabelInvalidException("Supported extensions are zip.", 422)
         if not utils.is_dicom_supported_size(file_path):
             raise FastLabelInvalidException("Supported image size is under 2 GB.", 422)
 
-        file = utils.base64_encode(file_path)
         payload = {"project": project}
         if status:
             payload["status"] = status
@@ -1568,8 +1569,12 @@ class Client:
 
         self.__fill_assign_users(payload, **kwargs)
 
-        signed_url = self.__get_signed_path(project = project, file_name = os.path.basename(file_path), file_type = "application/zip")
-        self.api.upload_zipfile(url = signed_url["url"], file_path = file_path)
+        signed_url = self.__get_signed_path(
+            project=project,
+            file_name=os.path.basename(file_path),
+            file_type="application/zip",
+        )
+        self.api.upload_zipfile(url=signed_url["url"], file_path=file_path)
 
         payload["fileKey"] = signed_url["name"]
         return self.api.post_request(endpoint, payload=payload)
@@ -3566,7 +3571,6 @@ class Client:
 
         return self.api.put_request(endpoint, payload=payload)
 
-
     def get_projects(
         self,
         slug: str = None,
@@ -3764,7 +3768,6 @@ class Client:
         type: str,
         name: str,
         slug: str,
-        annotation_type: str,
     ) -> dict:
         """
         Create a dataset.
@@ -3772,14 +3775,12 @@ class Client:
         type can be 'image', 'video', 'audio' (Required).
         name is name of your dataset (Required).
         slug is slug of your dataset (Required).
-        annotation_type can be 'none', 'image_bbox' (Required).
         """
         endpoint = "datasets"
         payload = {
             "type": type,
             "name": name,
             "slug": slug,
-            "annotationType": annotation_type,
         }
         return self.api.post_request(endpoint, payload=payload)
 
@@ -4132,11 +4133,10 @@ class Client:
                 "Limit must be less than or equal to 1000.", 422
             )
         endpoint = "tasks/import/histories"
-        params = { "project": project }
+        params = {"project": project}
         if offset:
             params["offset"] = offset
         if limit:
             params["limit"] = limit
 
         return self.api.get_request(endpoint, params=params)
-

--- a/tests/test_client_dataset.py
+++ b/tests/test_client_dataset.py
@@ -7,6 +7,12 @@ import pytest
 
 from fastlabel import Client, FastLabelInvalidException
 
+OBJECT_SIGNED_URL_KEY = "objectSignedUrl"
+
+
+def remove_object_signed_url(d: dict) -> dict:
+    return {k: v for k, v in d.items() if k != OBJECT_SIGNED_URL_KEY}
+
 
 @pytest.fixture
 def client() -> Client:
@@ -112,7 +118,9 @@ class TestImageDataset:
         # Act
         result = client.find_dataset_object(dataset_object_id=dataset_object["id"])
         # Assert
-        assert result == dataset_object
+        assert remove_object_signed_url(result) == remove_object_signed_url(
+            dataset_object
+        )
 
     def test_get_dataset_object(self, client: Client, testing_image_dataset: dict):
         # Arrange
@@ -132,45 +140,49 @@ class TestImageDataset:
         # Assert
         assert results is not None
         assert len(results) == 2
-        assert results[0] == dataset_object1
-        assert results[1] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            dataset_object1
+        )
+        assert remove_object_signed_url(results[1]) == remove_object_signed_url(
+            dataset_object2
+        )
 
     def test_delete_dataset_object(self, client: Client, testing_image_dataset: dict):
         # Arrange
         target_file = Path(sys.path[0]) / "files/test_image.jpg"
-        dataset_object1 = client.create_image_dataset_object(
-            dataset_id=testing_image_dataset["id"],
-            name="test_image1.jpg",
-            file_path=str(target_file),
-        )
-        dataset_object2 = client.create_image_dataset_object(
-            dataset_id=testing_image_dataset["id"],
-            name="test_image2.jpg",
-            file_path=str(target_file),
-        )
-        dataset_object3 = client.create_image_dataset_object(
-            dataset_id=testing_image_dataset["id"],
-            name="test_image3.jpg",
-            file_path=str(target_file),
-        )
+        dataset_object_names = ["test_image1.jpg", "test_image2.jpg", "test_image3.jpg"]
+        created = [
+            client.create_image_dataset_object(
+                dataset_id=testing_image_dataset["id"],
+                name=name,
+                file_path=str(target_file),
+            )
+            for name in dataset_object_names
+        ]
         dataset_objects = client.get_dataset_objects(
             dataset_id=testing_image_dataset["id"]
         )
         assert dataset_objects is not None
         assert len(dataset_objects) == 3
-        assert dataset_objects[0] == dataset_object1
-        assert dataset_objects[1] == dataset_object2
-        assert dataset_objects[2] == dataset_object3
+        for i, dataset_object in enumerate(dataset_objects):
+            assert OBJECT_SIGNED_URL_KEY in dataset_object
+            assert OBJECT_SIGNED_URL_KEY in created[i]
+            assert remove_object_signed_url(dataset_object) == remove_object_signed_url(
+                created[i]
+            )
+
         # Act
         client.delete_dataset_objects(
             dataset_id=testing_image_dataset["id"],
-            dataset_object_ids=[dataset_object1["id"], dataset_object3["id"]],
+            dataset_object_ids=[created[0]["id"], created[2]["id"]],
         )
         # Assert
         results = client.get_dataset_objects(dataset_id=testing_image_dataset["id"])
         assert results is not None
         assert len(results) == 1
-        assert results[0] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            created[1]
+        )
 
 
 class TestVideoDataset:
@@ -240,7 +252,9 @@ class TestVideoDataset:
         # Act
         result = client.find_dataset_object(dataset_object_id=dataset_object["id"])
         # Assert
-        assert result == dataset_object
+        assert remove_object_signed_url(result) == remove_object_signed_url(
+            dataset_object
+        )
 
     def test_get_dataset_object(self, client: Client, testing_video_dataset: dict):
         # Arrange
@@ -260,45 +274,50 @@ class TestVideoDataset:
         # Assert
         assert results is not None
         assert len(results) == 2
-        assert results[0] == dataset_object1
-        assert results[1] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            dataset_object1
+        )
+        assert remove_object_signed_url(results[1]) == remove_object_signed_url(
+            dataset_object2
+        )
 
     def test_delete_dataset_object(self, client: Client, testing_video_dataset: dict):
         # Arrange
         target_file = Path(sys.path[0]) / "files/test_video.mp4"
-        dataset_object1 = client.create_video_dataset_object(
-            dataset_id=testing_video_dataset["id"],
-            name="test_video1.mp4",
-            file_path=str(target_file),
-        )
-        dataset_object2 = client.create_video_dataset_object(
-            dataset_id=testing_video_dataset["id"],
-            name="test_video2.mp4",
-            file_path=str(target_file),
-        )
-        dataset_object3 = client.create_video_dataset_object(
-            dataset_id=testing_video_dataset["id"],
-            name="test_video3.mp4",
-            file_path=str(target_file),
-        )
+        dataset_object_names = ["test_video1.mp4", "test_video2.mp4", "test_video3.mp4"]
+        created = [
+            client.create_video_dataset_object(
+                dataset_id=testing_video_dataset["id"],
+                name=name,
+                file_path=str(target_file),
+            )
+            for name in dataset_object_names
+        ]
+
         dataset_objects = client.get_dataset_objects(
             dataset_id=testing_video_dataset["id"]
         )
         assert dataset_objects is not None
         assert len(dataset_objects) == 3
-        assert dataset_objects[0] == dataset_object1
-        assert dataset_objects[1] == dataset_object2
-        assert dataset_objects[2] == dataset_object3
+        for i, dataset_object in enumerate(dataset_objects):
+            assert OBJECT_SIGNED_URL_KEY in dataset_object
+            assert OBJECT_SIGNED_URL_KEY in created[i]
+            assert remove_object_signed_url(dataset_object) == remove_object_signed_url(
+                created[i]
+            )
+
         # Act
         client.delete_dataset_objects(
             dataset_id=testing_video_dataset["id"],
-            dataset_object_ids=[dataset_object1["id"], dataset_object3["id"]],
+            dataset_object_ids=[created[0]["id"], created[2]["id"]],
         )
         # Assert
         results = client.get_dataset_objects(dataset_id=testing_video_dataset["id"])
         assert results is not None
         assert len(results) == 1
-        assert results[0] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            created[1]
+        )
 
 
 class TestAudioDataset:
@@ -370,7 +389,9 @@ class TestAudioDataset:
         # Act
         result = client.find_dataset_object(dataset_object_id=dataset_object["id"])
         # Assert
-        assert result == dataset_object
+        assert remove_object_signed_url(result) == remove_object_signed_url(
+            dataset_object
+        )
 
     def test_get_dataset_object(self, client: Client, testing_audio_dataset: dict):
         # Arrange
@@ -390,45 +411,47 @@ class TestAudioDataset:
         # Assert
         assert results is not None
         assert len(results) == 2
-        assert results[0] == dataset_object1
-        assert results[1] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            dataset_object1
+        )
+        assert remove_object_signed_url(results[1]) == remove_object_signed_url(
+            dataset_object2
+        )
 
     def test_delete_dataset_object(self, client: Client, testing_audio_dataset: dict):
         # Arrange
         target_file = Path(sys.path[0]) / "files/test_audio.mp3"
-        dataset_object1 = client.create_audio_dataset_object(
-            dataset_id=testing_audio_dataset["id"],
-            name="test_audio1.mp3",
-            file_path=str(target_file),
-        )
-        dataset_object2 = client.create_audio_dataset_object(
-            dataset_id=testing_audio_dataset["id"],
-            name="test_audio2.mp3",
-            file_path=str(target_file),
-        )
-        dataset_object3 = client.create_audio_dataset_object(
-            dataset_id=testing_audio_dataset["id"],
-            name="test_audio3.mp3",
-            file_path=str(target_file),
-        )
+        dataset_object_names = ["test_audio1.mp3", "test_audio2.mp3", "test_audio3.mp3"]
+        created = [
+            client.create_audio_dataset_object(
+                dataset_id=testing_audio_dataset["id"],
+                name=name,
+                file_path=str(target_file),
+            )
+            for name in dataset_object_names
+        ]
         dataset_objects = client.get_dataset_objects(
             dataset_id=testing_audio_dataset["id"]
         )
-        assert dataset_objects is not None
-        assert len(dataset_objects) == 3
-        assert dataset_objects[0] == dataset_object1
-        assert dataset_objects[1] == dataset_object2
-        assert dataset_objects[2] == dataset_object3
+        for i, dataset_object in enumerate(dataset_objects):
+            assert OBJECT_SIGNED_URL_KEY in dataset_object
+            assert OBJECT_SIGNED_URL_KEY in created[i]
+            assert remove_object_signed_url(dataset_object) == remove_object_signed_url(
+                created[i]
+            )
+
         # Act
         client.delete_dataset_objects(
             dataset_id=testing_audio_dataset["id"],
-            dataset_object_ids=[dataset_object1["id"], dataset_object3["id"]],
+            dataset_object_ids=[created[0]["id"], created[2]["id"]],
         )
         # Assert
         results = client.get_dataset_objects(dataset_id=testing_audio_dataset["id"])
         assert results is not None
         assert len(results) == 1
-        assert results[0] == dataset_object2
+        assert remove_object_signed_url(results[0]) == remove_object_signed_url(
+            created[1]
+        )
 
 
 class TestDatasetObjectImportHistories:


### PR DESCRIPTION
# issue
- [データセット] アノテーションタイプ削除

## 編集したファイルについて
主となる編集は `fastlabel/__init__.py` の `create_dataset` メソッドから `annotation_type` 引数を削除した部分のみとなります。

テストを実行してみたところ、`get_dataset_objects` の返り値には `objectSignedUrl` があるのに、`create_*_dataset_object` にはなかったためエラーが起きていました。オブジェクトの作成時にも `objectSignedUrl` を返すようにAPI側を修正しました。

また、`pre-commit` の `isort` でエラーが起きていたのでバージョンを更新しました。（[参考](https://stackoverflow.com/questions/75281731/pre-commit-fails-to-install-isort-5-10-1-with-error-runtimeerror-the-poetry-co)）

`isort` のバージョンは python3.7 でも動くように 5.11.5 にしています。