### PR TITLE
Add attributes to coco annotations

### DIFF
--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -1,4 +1,5 @@
 import math
+from typing import Union
 from enum import Enum
 
 # only 57 types
@@ -221,6 +222,8 @@ SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)
 
+AttributeValue = Union[str, list[str], float, list[float]]
+
 
 class AnnotationType(Enum):
     bbox = "bbox"
@@ -232,9 +235,9 @@ class AnnotationType(Enum):
     classification = "classification"
     pose_estimation = "pose_estimation"
 
+
 class Priority(Enum):
     none = 0
     low = 10
     medium = 20
     high = 30
-

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -1,5 +1,5 @@
 import math
-from typing import Union
+from typing import Union, List
 from enum import Enum
 
 # only 57 types
@@ -222,7 +222,7 @@ SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)
 
-AttributeValue = Union[str, list[str], float, list[float]]
+AttributeValue = Union[str, List[str], float, List[float]]
 
 
 class AnnotationType(Enum):

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -860,11 +860,10 @@ def execute_coco_to_fastlabel(coco: dict, annotation_type: str) -> dict:
 
         annotations = []
         for target_coco_annotation in target_coco_annotations:
+            attributes_items = target_coco_annotation.get("attributes", {})
             attributes = [
                 {"key": attribute_key, "value": attribute_value}
-                for attribute_key, attribute_value in target_coco_annotation[
-                    "attributes"
-                ].items()
+                for attribute_key, attribute_value in attributes_items.items()
             ]
             category_name = coco_categories[target_coco_annotation["category_id"]]
             if not category_name:

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -74,6 +74,7 @@ def to_coco(
                     "annotation_type": annotation["type"],
                     "annotation_points": get_annotation_points(annotation, index),
                     "annotation_keypoints": annotation.get("keypoints"),
+                    "annotation_attributes": annotation.get("attributes"),
                     "categories": categories,
                     "image_id": task_image["id"],
                 }
@@ -204,6 +205,7 @@ def __to_coco_annotation(data: dict) -> dict:
     annotation_type = data["annotation_type"]
     annotation_value = data["annotation_value"]
     annotation_id = 0
+    annotation_attributes = data["annotation_attributes"]
 
     if annotation_type not in [
         AnnotationType.bbox.value,
@@ -226,7 +228,7 @@ def __to_coco_annotation(data: dict) -> dict:
         return None
 
     return __get_coco_annotation(
-        annotation_id, points, keypoints, category["id"], image_id, annotation_type
+        annotation_id, points, keypoints, category["id"], image_id, annotation_type, annotation_attributes
     )
 
 
@@ -259,6 +261,7 @@ def __get_coco_annotation(
     category_id: int,
     image_id: str,
     annotation_type: str,
+    annotation_attributes: dict[str, any],
 ) -> dict:
     annotation = {}
     annotation["num_keypoints"] = len(keypoints) if keypoints else 0
@@ -272,6 +275,7 @@ def __get_coco_annotation(
     annotation["bbox"] = __to_bbox(annotation_type, points)
     annotation["category_id"] = category_id
     annotation["id"] = id_
+    annotation["attributes"] = annotation_attributes
     return annotation
 
 

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -15,7 +15,7 @@ import geojson
 import numpy as np
 import requests
 
-from fastlabel.const import AnnotationType
+from fastlabel.const import AnnotationType, AttributeValue
 from fastlabel.exceptions import FastLabelInvalidException
 from fastlabel.utils import is_video_project_type
 
@@ -269,7 +269,7 @@ def __get_coco_annotation(
     category_id: int,
     image_id: str,
     annotation_type: str,
-    annotation_attributes: dict[str, any],
+    annotation_attributes: dict[str, AttributeValue],
 ) -> dict:
     annotation = {}
     annotation["num_keypoints"] = len(keypoints) if keypoints else 0
@@ -1129,7 +1129,7 @@ def _get_annotation_points_for_image_annotation(annotation: dict):
     return annotation.get("points")
 
 
-def _get_coco_annotation_attributes(annotation: dict) -> dict[str, any]:
+def _get_coco_annotation_attributes(annotation: dict) -> dict[str, AttributeValue]:
     coco_attributes = {}
     attributes = annotation.get("attributes")
     if not attributes:


### PR DESCRIPTION
## 概要
- export_cocoとconvert_coco_to_fastlabelでのcocoフォーマットにアプリ側に対応したattributes情報を追加しました

## 背景
- FastLabelのアプリ側のcocoフォーマットにattributesが追加されたため

## 動作確認
- export_cocoが下記プロジェクトに対して正常動作すること
   - 画像-矩形
   - 画像-多角形
   - 画像-姿勢推定
- convert_coco_to_fastlabelが下記プロジェクトに対して正常動作すること
   - 画像-矩形
   - 画像-多角形
   - 画像-姿勢推定
      - attributesの追加については正常に行われたが、keypointsの取得ができないことが判明した
      - 別途対応する必要がある