### PR TITLE
pillow update ver_10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,30 +9,30 @@ jobs:
   build-n-publish:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
 
-    - name: Build
-      run: |
-        python setup.py sdist
-        python setup.py bdist_wheel
+      - name: Build
+        run: |
+          python setup.py sdist
+          python setup.py bdist_wheel
 
-    - name: Check
-      run: |
-        ls ./dist
+      - name: Check
+        run: |
+          ls ./dist
 
-    - name: Publish a Python distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish a Python distribution to PyPI
+        if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 pip install --upgrade fastlabel
 ```
 
-> Python version 3.7 or greater is required
+> Python version 3.8 or greater is required
 
 ## Usage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests==2.25.1
 numpy>=1.21.2
 geojson==2.5.0
 xmltodict==0.12.0
-Pillow>=9.0.1,<10.0.0
+Pillow>=10.0.0,<11.0.0
 opencv-python==4.7.0.72

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires=install_requires,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     use_scm_version=True,
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
# 概要

9/4 よりメールで報告していた通りpillowのバージョンアップでpython3.7のサポート終了。
Pillowは画像処理で使用するので画像出力関連のメソッドをテストする。


# テストケース
pythonバージョン
・3.8.17
・3.9.16
・3.10.12
・3.11.4

Pillowバージョン
・10.0.0

- [x] export_instance_segmentationでインスタンス画像出力できること
- [x] export_semantic_segmentationでセマンティック画像出力できること
- [x] export_image_with_annotationsでアノテーション付き画像が出力できること

# テスト動画

https://github.com/fastlabel/fastlabel-python-sdk/assets/114887968/c85399df-7a3f-4960-91eb-615f3c342274



