### PR TITLE
add: download dataset objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2615,7 +2615,7 @@ client.download_dataset_objects(
   path="YOUR_DOWNLOAD_PATH",
   version="latest", # default is "latest"
   tags=["cat"],
-  types=["train", "valid"],
+  types=["train", "valid"],  # choices are "train", "valid", "test" and "none" (Optional)
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -2603,6 +2603,22 @@ dataset_objects = client.get_dataset_objects(
 )
 ```
 
+### Download Dataset Objects
+
+Download dataset objects in the dataset to specific directories.
+
+You can filter by version, tags and types.
+
+```python
+client.download_dataset_objects(
+  dataset="YOUR_DATASET_NAME",
+  path="YOUR_DOWNLOAD_PATH",
+  version="latest", # default is "latest"
+  tags=["cat"],
+  types=["train", "valid"],
+)
+```
+
 ### Delete Dataset Object
 
 Delete a single dataset object.

--- a/examples/download_dataset_objects.py
+++ b/examples/download_dataset_objects.py
@@ -1,0 +1,7 @@
+import fastlabel
+
+client = fastlabel.Client()
+
+client.download_dataset_objects(
+    dataset="object-detection", path="./downloads", types=["train", "valid"]
+)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -1,11 +1,14 @@
+import asyncio
 import glob
 import json
 import logging
 import os
 import re
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Optional
+from pathlib import Path
+from typing import List, Optional, Union
 
+import aiohttp
 import cv2
 import numpy as np
 import xmltodict
@@ -20,6 +23,7 @@ from fastlabel.const import (
     POSE_ESTIMATION_MIN_STROKE_WIDTH,
     SEPARATOER,
     AnnotationType,
+    DatasetObjectType,
     Priority,
 )
 
@@ -3909,10 +3913,7 @@ class Client:
         return self.api.get_request(endpoint)
 
     def get_dataset_objects(
-        self,
-        dataset: str,
-        version: str = None,
-        tags: List[str] = [],
+        self, dataset: str, version: str = None, tags: List[str] = []
     ) -> list:
         """
         Returns a list of dataset objects.
@@ -3928,6 +3929,77 @@ class Client:
         if tags:
             params["tags"] = tags
         return self.api.get_request(endpoint, params=params)
+
+    def download_dataset_objects(
+        self,
+        dataset: str,
+        path: str,
+        version: str = "",
+        tags: Optional[List[str]] = None,
+        types: Optional[List[Union[str, DatasetObjectType]]] = None,
+    ):
+        endpoint = "dataset-objects/signed-urls"
+        params = {"dataset": dataset}
+        if version:
+            params["version"] = version
+        if tags:
+            params["tags"] = tags
+        if types:
+            try:
+                types = list(
+                    map(
+                        lambda t: t
+                        if isinstance(t, DatasetObjectType)
+                        else DatasetObjectType(t),
+                        types,
+                    )
+                )
+            except ValueError:
+                raise FastLabelInvalidException(
+                    f"types must be {[k for k in DatasetObjectType.__members__.keys()]}.",
+                    422,
+                )
+            params["types"] = [t.value for t in types]
+
+        response = self.api.get_request(endpoint, params=params)
+
+        download_path = Path(path)
+        download_path.mkdir(exist_ok=True)
+        object_map = {}
+        if types:
+            for type_ in types:
+                (download_path / type_.value).mkdir(exist_ok=True)
+                object_map[type_.value] = [
+                    obj for obj in response if obj["type"] == type_.value
+                ]
+        else:
+            object_map[""] = response
+
+        sem = asyncio.Semaphore(10)
+
+        async def __download(base_path: Path, _obj: dict):
+            async with sem:
+                await self.__download_dataset_object(base_path, _obj)
+
+        for _type, objects in object_map.items():
+            base_path = download_path / _type
+            loop = asyncio.get_event_loop()
+            loop.run_until_complete(
+                asyncio.gather(*[__download(base_path, obj) for obj in objects])
+            )
+            with Path(base_path / "annotations.json").open("w") as f:
+                annotations = [
+                    {"name": obj["name"], "annotations": obj["annotations"]}
+                    for obj in objects
+                ]
+                json.dump(annotations, fp=f, indent=4)
+
+    async def __download_dataset_object(self, download_path: Path, obj: dict):
+        obj_path = download_path / obj["name"]
+        async with aiohttp.ClientSession() as session:
+            async with session.get(obj["signedUrl"]) as response:
+                with obj_path.open("wb") as f:
+                    f.write(await response.read())
 
     def create_dataset_object(
         self,

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -244,3 +244,10 @@ class Priority(Enum):
     low = 10
     medium = 20
     high = 30
+
+
+class DatasetObjectType(Enum):
+    none = "none"
+    train = "train"
+    valid = "valid"
+    test = "test"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ geojson==2.5.0
 xmltodict==0.12.0
 Pillow>=10.0.0,<11.0.0
 opencv-python==4.7.0.72
+aiohttp>=3.8.5


### PR DESCRIPTION
# issue
- [データセットのオブジェクトをtrain,valid,testに割り振れる](https://github.com/fastlabel/roadmap/issues/20)

# 仕様
引数などは↓を参照
https://github.com/fastlabel/roadmap/issues/20#issuecomment-1726824682

# test

実際に実行した形

4743 件のデータセットに対して、train:valid:test = 7 : 3 : 1  に分けたデータセットに対して実行
4269 件のダウンロードで約1分

https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/5ce86d53-4853-4dd3-9ea2-4e09aa3fb9b9

train: 3321 (annotation.json を含む)
valid: 950

<img width="725" alt="スクリーンショット 2023-09-21 12 42 06" src="https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/829b3ad4-58a9-4dc5-882f-86ee9152b448">

