### PR TITLE
SDKで動画のタスク登録するときに、動画のコーデックがH.264のものではない場合はエラーを返す

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,8 @@ task_id = client.create_video_task(
 ##### Limitation
 
 - You can upload up to a size of 250 MB.
+- You can upload only videos with H.264 encoding.
+- You can upload only MP4 file format.
 
 #### Find Task
 

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -1252,6 +1252,10 @@ class Client:
             raise FastLabelInvalidException(
                 "Supported video size is under 250 MB.", 422
             )
+        if not utils.is_video_supported_codec(file_path):
+            raise FastLabelInvalidException(
+                "Supported codec is H.264.", 422
+            )
 
         file = utils.base64_encode(file_path)
         payload = {"project": project, "name": name, "file": file}
@@ -1315,6 +1319,10 @@ class Client:
         if not utils.is_video_supported_size(file_path):
             raise FastLabelInvalidException(
                 "Supported video size is under 250 MB.", 422
+            )
+        if not utils.is_video_supported_codec(file_path):
+            raise FastLabelInvalidException(
+                "Supported codec is H.264.", 422
             )
 
         file = utils.base64_encode(file_path)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -1254,7 +1254,7 @@ class Client:
             )
         if not utils.is_video_supported_codec(file_path):
             raise FastLabelInvalidException(
-                "Supported codec is H.264.", 422
+                "Supported video encoding for registration through the SDK is only H.264.", 422
             )
 
         file = utils.base64_encode(file_path)
@@ -1322,7 +1322,7 @@ class Client:
             )
         if not utils.is_video_supported_codec(file_path):
             raise FastLabelInvalidException(
-                "Supported codec is H.264.", 422
+                "Supported video encoding for registration through the SDK is only H.264.", 422
             )
 
         file = utils.base64_encode(file_path)

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -222,6 +222,9 @@ SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
 # API can accept under 250 MB
 SUPPORTED_OBJECT_SIZE = 250 * math.pow(1024, 2)
 
+# Only 'avc1' and 'H264' are supported for video task creation.
+SUPPORTED_CODECS = ["avc1", "H264"]
+
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)
 

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -223,7 +223,7 @@ SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
 SUPPORTED_OBJECT_SIZE = 250 * math.pow(1024, 2)
 
 # Only 'avc1' and 'H264' are supported for video task creation.
-SUPPORTED_CODECS = ["avc1", "H264"]
+SUPPORTED_CODECS = ["avc1"]
 
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -223,7 +223,7 @@ SUPPORTED_PCD_SIZE = 30 * math.pow(1024, 2)
 SUPPORTED_OBJECT_SIZE = 250 * math.pow(1024, 2)
 
 # Only 'avc1' and 'H264' are supported for video task creation.
-SUPPORTED_CODECS = ["avc1"]
+SUPPORTED_FOURCC = ["avc1"]
 
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)

--- a/fastlabel/utils.py
+++ b/fastlabel/utils.py
@@ -5,6 +5,7 @@ from typing import List
 
 import geojson
 import numpy as np
+import cv2
 
 from fastlabel import const
 
@@ -16,6 +17,10 @@ def base64_encode(file_path: str) -> str:
 
 def is_image_supported_ext(file_path: str) -> bool:
     return file_path.lower().endswith((".png", ".jpg", ".jpeg"))
+
+
+def is_video_supported_codec(file_path: str) -> bool:
+    return get_video_codec(file_path) in const.SUPPORTED_CODECS
 
 
 def is_video_supported_ext(file_path: str) -> bool:
@@ -164,3 +169,11 @@ def is_clockwise(points: list) -> bool:
 def get_json_length(value) -> int:
     json_str = json.dumps(value)
     return len(json_str)
+
+
+def get_video_codec(video_path: str) -> str:
+    cap = cv2.VideoCapture(video_path)
+    fourcc_code = int(cap.get(cv2.CAP_PROP_FOURCC))
+    fourcc_str = "".join([chr((fourcc_code >> 8 * i) & 0xFF) for i in range(4)])
+    cap.release()
+    return fourcc_str

--- a/fastlabel/utils.py
+++ b/fastlabel/utils.py
@@ -20,7 +20,7 @@ def is_image_supported_ext(file_path: str) -> bool:
 
 
 def is_video_supported_codec(file_path: str) -> bool:
-    return get_video_codec(file_path) in const.SUPPORTED_CODECS
+    return get_video_fourcc(file_path) in const.SUPPORTED_FOURCC
 
 
 def is_video_supported_ext(file_path: str) -> bool:
@@ -171,7 +171,7 @@ def get_json_length(value) -> int:
     return len(json_str)
 
 
-def get_video_codec(video_path: str) -> str:
+def get_video_fourcc(video_path: str) -> str:
     cap = cv2.VideoCapture(video_path)
     fourcc_code = int(cap.get(cv2.CAP_PROP_FOURCC))
     fourcc_str = "".join([chr((fourcc_code >> 8 * i) & 0xFF) for i in range(4)])


### PR DESCRIPTION
## 概要
- 動画タスク作成時に動画のコーデックがH.264でない場合はエラーを返すようにしました

## 背景
- SDKでの動画タスク作成の場合、MP4ファイルのH.264でない場合はFastLabelのアプリで動画を正常に表示することができません
- 拡張子がmp4であるかどうかのバリデーションは行われていましたが、拡張子がmp4であってもコーデックがHEVCなどサポートしていなコーデックの場合がありました
- そのため、コーデックについてのバリデーションを追加しました

## やったこと
- コーデックのバリデーションの追加

## 動作確認

<img width="902" alt="スクリーンショット 2023-09-21 17 48 30" src="https://github.com/fastlabel/fastlabel-python-sdk/assets/61764395/d122d150-e42c-4901-b03b-91dc51d3b74f">

<img width="895" alt="スクリーンショット 2023-09-21 17 50 23" src="https://github.com/fastlabel/fastlabel-python-sdk/assets/61764395/38a427f1-92c5-4734-8843-f4f65e1d7397">
