### PR TITLE
fix dict type hint

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from operator import itemgetter
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import List, Optional
+from typing import List, Dict, Optional
 
 import cv2
 import geojson
@@ -269,7 +269,7 @@ def __get_coco_annotation(
     category_id: int,
     image_id: str,
     annotation_type: str,
-    annotation_attributes: dict[str, AttributeValue],
+    annotation_attributes: Dict[str, AttributeValue],
 ) -> dict:
     annotation = {}
     annotation["num_keypoints"] = len(keypoints) if keypoints else 0
@@ -1128,7 +1128,7 @@ def _get_annotation_points_for_image_annotation(annotation: dict):
     return annotation.get("points")
 
 
-def _get_coco_annotation_attributes(annotation: dict) -> dict[str, AttributeValue]:
+def _get_coco_annotation_attributes(annotation: dict) -> Dict[str, AttributeValue]:
     coco_attributes = {}
     attributes = annotation.get("attributes")
     if not attributes:


### PR DESCRIPTION
## 概要

COCO出力の際に辞書形式のTypeHintが3.9以降の書き方のため3.8で動作しない不具合の修正

## テスト

- [x] python 3.8.18でpip install時にエラーがでないこと
- [x] python 3.8.18でCOCO出力が動作すること

# UI

pip install

https://github.com/fastlabel/fastlabel-python-sdk/assets/114887968/db6fd29f-be3c-42be-99f1-9477f7826518

export coco


https://github.com/fastlabel/fastlabel-python-sdk/assets/114887968/3d0e8c98-2f05-407a-b539-b2c7db6b70ae

