### PR TITLE
fix: download by annotations and attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ output/
 .venv/
 .env
 !tests/files/*
+.idea/

--- a/README.md
+++ b/README.md
@@ -2619,6 +2619,10 @@ client.download_dataset_objects(
   version="latest", # default is "latest"
   tags=["cat"],
   types=["train", "valid"],  # choices are "train", "valid", "test" and "none" (Optional)
+  annotations=["face", "tail"],
+  attributes=[
+    {"name": "breed", "value": "munchkin"},
+  ]
 )
 ```
 

--- a/examples/download_dataset_objects.py
+++ b/examples/download_dataset_objects.py
@@ -3,5 +3,11 @@ import fastlabel
 client = fastlabel.Client()
 
 client.download_dataset_objects(
-    dataset="object-detection", path="./downloads", types=["train", "valid"]
+    dataset="object-detection",
+    path="./downloads",
+    types=["train", "valid"],
+    annotations=["face", "tail"],
+    attributes=[
+        {"name": "breed", "value": "munchkin"},
+    ],
 )

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -26,6 +26,7 @@ from fastlabel.const import (
     DatasetObjectType,
     Priority,
 )
+from fastlabel.types import DatasetObjectAttributeType
 
 from .api import Api
 from .exceptions import FastLabelInvalidException
@@ -3947,6 +3948,8 @@ class Client:
         version: str = "",
         tags: Optional[List[str]] = None,
         types: Optional[List[Union[str, DatasetObjectType]]] = None,
+        annotations: Optional[List[str]] = None,
+        attributes: Optional[List[DatasetObjectAttributeType]] = None,
     ):
         endpoint = "dataset-objects/signed-urls"
         params = {"dataset": dataset}
@@ -3970,6 +3973,10 @@ class Client:
                     422,
                 )
             params["types"] = [t.value for t in types]
+        if annotations:
+            params["annotations"] = annotations
+        if attributes:
+            params["attributes"] = json.dumps(attributes)
 
         response = self.api.get_request(endpoint, params=params)
 

--- a/fastlabel/types.py
+++ b/fastlabel/types.py
@@ -1,0 +1,6 @@
+from typing import TypedDict
+
+
+class DatasetObjectAttributeType(TypedDict):
+    name: str
+    value: str


### PR DESCRIPTION
# issue
[データセット] データセットに対してアノテーションクラス・タグ・属性を指定してエクスポートできる

