### PR TITLE
Adjusted to prioritize 'name' from COCO format as FastLabel value

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -844,8 +844,8 @@ def execute_coco_to_fastlabel(coco: dict, annotation_type: str) -> dict:
     coco_categories = {}
     coco_categories_keypoints = {}
     for c in coco["categories"]:
-        coco_categories[c["id"]] = c["supercategory"]
-        coco_categories_keypoints[c["id"]] = c["keypoints"]
+        coco_categories[c["id"]] = c["name"] if c.get("name") else c["supercategory"]
+        coco_categories_keypoints[c["id"]] = c["keypoints"] if c.get("keypoints") else []
 
     coco_annotations = coco["annotations"]
 


### PR DESCRIPTION
## やったこと
- coco形式からfastlabel形式に変換する時に、coco形式のcategoriesのnameを優先的にfastlabel形式のアノテーションクラスのvalueにするように更新しました
- coco annotatorからダウンロードしたアノテーションファイルのcategoriesにはkeypointsが存在しない場合があるため、keypointsが存在しない場合は空配列を使用するように修正しました