### PR TITLE
feat: create and download custom metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2514,7 +2514,11 @@ dataset_object = client.create_dataset_object(
             "value": "dog",
             "type": "bbox" # type can be 'bbox', 'segmentation'.
         }
-    ]
+    ],
+    custom_metadata={
+      "key": "value",
+      "metadata": "metadata-value"
+    }
 )
 ```
 
@@ -2568,6 +2572,10 @@ See API docs for details.
             "confidenceScore": -1
         }
     ],
+  "customMetadata": {
+    "key": "value",
+    "metadata": "metadata-value"
+  },
     'createdAt': '2022-10-30T08:32:20.748Z',
     'updatedAt': '2022-10-30T08:32:20.748Z'
 }

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4050,7 +4050,11 @@ class Client:
                 exist_dataset_objects = json.load(open(output_path))
             with Path(base_path / "annotations.json").open("w") as f:
                 annotations = [
-                    {"name": obj["name"], "annotations": obj["annotations"]}
+                    {
+                        "name": obj["name"],
+                        "annotations": obj["annotations"],
+                        "customMetadata": obj["customMetadata"],
+                    }
                     for obj in objects
                 ]
                 json.dump(
@@ -4076,6 +4080,7 @@ class Client:
         file_path: str,
         tags: List[str] = None,
         annotations: List[dict] = None,
+        custom_metadata: Optional[dict[str, str]] = None,
     ) -> dict:
         """
         Create a dataset object.
@@ -4102,6 +4107,8 @@ class Client:
             payload["tags"] = tags
         if annotations:
             payload["annotations"] = annotations
+        if custom_metadata:
+            payload["customMetadata"] = custom_metadata
         return self.api.post_request(endpoint, payload=payload)
 
     def delete_dataset_object(self, dataset_id: str, object_name: str) -> None:
@@ -4417,6 +4424,7 @@ class Client:
             params["limit"] = limit
 
         return self.api.get_request(endpoint, params=params)
+
 
 def delete_extra_annotations_parameter(annotations: list) -> list:
     for annotation in annotations:


### PR DESCRIPTION
# issue
- ユーザーごとの独自のメタデータを管理・検索できる

## 仕様
- sdk でカスタムメタデータを使えるようにする

## test

データセット作成時にカスタムメタデータを登録できる
```python3
client.create_dataset_object(custom_metadata={"key": "value"})
```
![スクリーンショット 2024-01-16 23 27 39](https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/fbdca152-d063-41c1-b9a3-efe62eccf36a)

ダウンロード結果にカスタムメタデータが登録されている
```python3
client.download_dataset_objects()
```

![スクリーンショット 2024-01-16 23 27 53](https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/6b365af1-1e92-42b7-8677-eadb9fb1547e)

<img width="949" alt="スクリーンショット 2024-01-16 23 30 51" src="https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/0dd8ddbc-ab65-499c-90a9-ac639778dee5">



