### PR TITLE
feat: api resize option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3096,9 +3096,8 @@ training_job = client.execute_training_job(
     base_model_name="fastlabel_object_detection_light",  // "fastlabel_object_detection_light" or "fastlabel_object_detection_high_accuracy" or "fastlabel_u_net_general"
     epoch=300,
     use_dataset_train_val=True,
-    resize_option="fixed",  // "fixed" or "none"
-    resize_width=1024,
-    resize_height=1024,
+    resize_option="fixed",  // optional, "fixed" or "none"
+    resize_dimension=1024, // optional, 512 or 1024
 )
 
 ```

--- a/README.md
+++ b/README.md
@@ -3093,9 +3093,12 @@ Get training jobs.
 ```python
 training_job = client.execute_training_job(
     dataset_name="dataset_name",
-    base_model_name="fastlabel_object_detection_light",  // "fastlabel_object_detection_light" or "fastlabel_object_detection_high_accuracy"
+    base_model_name="fastlabel_object_detection_light",  // "fastlabel_object_detection_light" or "fastlabel_object_detection_high_accuracy" or "fastlabel_u_net_general"
     epoch=300,
-    use_dataset_train_val=True
+    use_dataset_train_val=True,
+    resize_option="fixed",  // "fixed" or "none"
+    resize_width=1024,
+    resize_height=1024,
 )
 
 ```

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4249,8 +4249,7 @@ class Client:
         batch_size: int = None,
         learning_rate: float = None,
         resize_option: str = Literal["fixed", "none"],
-        resize_height: Optional[int] = None,
-        resize_width: Optional[int] = None,
+        resize_dimension: Optional[int] = None,
     ) -> list:
         """
         Returns a list of training jobs.
@@ -4270,8 +4269,7 @@ class Client:
             "batchSize": batch_size,
             "learningRate": learning_rate,
             "resizeOption": resize_option,
-            "resizeHeight": resize_height,
-            "resizeWidth": resize_width,
+            "resizeDimension": resize_dimension,
         }
 
         return self.api.post_request(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -6,7 +6,7 @@ import os
 import re
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 import aiohttp
 import cv2
@@ -4248,6 +4248,9 @@ class Client:
         instance_type: str = "ml.p3.2xlarge",
         batch_size: int = None,
         learning_rate: float = None,
+        resize_option: str = Literal["fixed", "none"],
+        resize_height: Optional[int] = None,
+        resize_width: Optional[int] = None,
     ) -> list:
         """
         Returns a list of training jobs.
@@ -4266,6 +4269,9 @@ class Client:
             "instanceType": instance_type,
             "batchSize": batch_size,
             "learningRate": learning_rate,
+            "resizeOption": resize_option,
+            "resizeHeight": resize_height,
+            "resizeWidth": resize_width,
         }
 
         return self.api.post_request(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4248,7 +4248,7 @@ class Client:
         instance_type: str = "ml.p3.2xlarge",
         batch_size: int = None,
         learning_rate: float = None,
-        resize_option: str = Literal["fixed", "none"],
+        resize_option: Optional[Literal["fixed", "none"]] = None,
         resize_dimension: Optional[int] = None,
     ) -> list:
         """


### PR DESCRIPTION
u-net で使う、resize 関連のオプションを指定できるように修正しました。
```python3
training_job = client.execute_training_job(
    dataset_name="dataset_name",
    base_model_name="fastlabel_object_detection_light",  // "fastlabel_object_detection_light" or "fastlabel_object_detection_high_accuracy" or "fastlabel_u_net_general"
    epoch=300,
    use_dataset_train_val=True,
    resize_option="fixed",  // "fixed" or "none"
    resize_dimension=1024
)
```

![スクリーンショット 2024-01-22 21 12 01](https://github.com/fastlabel/fastlabel-python-sdk/assets/48790874/502a187c-7710-4fb6-8125-4b03212fa7a0)
