### PR TITLE
fix: support h264 that was previously determined to be avc1

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -1267,7 +1267,7 @@ class Client:
             )
         if not utils.is_video_supported_codec(file_path):
             raise FastLabelInvalidException(
-                "Supported video encoding for registration through the SDK is only H.264.",
+                "Supported video encoding for registration through the SDK is only AVC/H.264",
                 422,
             )
 
@@ -1336,7 +1336,7 @@ class Client:
             )
         if not utils.is_video_supported_codec(file_path):
             raise FastLabelInvalidException(
-                "Supported video encoding for registration through the SDK is only H.264.",
+                "Supported video encoding for registration through the SDK is only AVC/H.264",
                 422,
             )
 

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -223,7 +223,7 @@ SUPPORTED_PCD_SIZE = 100 * math.pow(1024, 2)
 SUPPORTED_OBJECT_SIZE = 250 * math.pow(1024, 2)
 
 # Only 'avc1' and 'H264' are supported for video task creation.
-SUPPORTED_FOURCC = ["avc1"]
+SUPPORTED_FOURCC = ["avc1", "h264"]
 
 
 SUPPORTED_INFERENCE_IMAGE_SIZE = 6 * math.pow(1024, 2)


### PR DESCRIPTION
## 背景
SDKのrequirements.txtの依存ライブラリの範囲拡張を行った際、ライブラリのアップデートにより、SDK内のビデオコーデックの判定ロジックの出力が変わっていたことが判明しました。
OpenCVのアップデートにより、前までコーデックがavc1と判定されていた動画がh264と判定されるようになっています。
これにより、SDK内の一部関数に不具合が生じておりその対応。

## 変更根拠
avc1とh264は技術的に同じもので標準化団体の呼び方として違いがあるようです。よって新しいバージョンでh264と判定される動画は古いバージョンでavc1と判定される動画と一致すると考えて良さそうです。
これが正しいか、OpenCVのアップデート履歴から調べようとしましたが、情報が見つからなかったため以下の検証をしています。

1. Open CVのライブラリのバージョンの新旧でビデオコーデックの判定結果が旧:avc1、新:h264となることを以下の動画において確認
・フリー動画mp4（サイトA）
・フリー動画mp4（サイトB）
・動画編集ソフト(Filmora)で出力したmp4
・ipnoneで撮影したmov

2. 変更したSDKを用いてh264と判定される動画をローカル環境に取り込み、以下の操作ができることを確認
・タスクの取り込み
・アノテーション画面における動画再生
・アノテーションの実施、保存