### PR TITLE
download と get の引数を同じにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -2639,7 +2639,10 @@ dataset_objects = client.get_dataset_objects(
     dataset="YOUR_DATASET_NAME",
     version="latest", # default is "latest"
     tags=["cat"],
-    licenses=["MIT"]
+    licenses=["fastlabel"],
+    types=["train", "valid"],  # choices are "train", "valid", "test" and "none" (Optional)
+    offset=0,  # default is 0 (Optional)
+    limit=1000,  # default is 1000, and must be less than 1000 (Optional)
 )
 ```
 
@@ -2663,6 +2666,9 @@ client.download_dataset_objects(
   version="latest", # default is "latest"
   tags=["cat"],
   types=["train", "valid"],  # choices are "train", "valid", "test" and "none" (Optional)
+  licenses=["fastlabel"],
+  offset=0,  # default is 0 (Optional)
+  limit=1000,  # default is 1000, and must be less than 1000 (Optional)
 )
 ```
 

--- a/fastlabel/const.py
+++ b/fastlabel/const.py
@@ -254,3 +254,15 @@ class DatasetObjectType(Enum):
     train = "train"
     valid = "valid"
     test = "test"
+
+    @classmethod
+    def create(cls, value: "str | DatasetObjectType") -> "DatasetObjectType":
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(value)
+        except ValueError:
+            raise ValueError(
+                f"Invalid DatasetObjectType: {value}. "
+                f"types must be {[k for k in DatasetObjectType.__members__.keys()]}"
+            )

--- a/fastlabel/query.py
+++ b/fastlabel/query.py
@@ -1,0 +1,12 @@
+from typing import List, Optional, TypedDict
+
+
+class DatasetObjectGetQuery(TypedDict, total=False):
+    dataset: str
+    version: str
+    revisionId: str
+    tags: Optional[List[str]]
+    licenses: Optional[List[str]]
+    types: Optional[List[str]]
+    offset: int
+    limit: int


### PR DESCRIPTION
## 対応したこと
download_dataset_objects / get_dataset_objects で検索条件が同じになるように修正した。
API側でロジックを統一したため