### PR TITLE
Fixed export_coco to support pose estimation

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -405,7 +405,10 @@ def __to_area(annotation_type: str, points: list) -> float:
 def __calc_area(annotation_type: str, points: list) -> float:
     if not points:
         return 0
-    if annotation_type == AnnotationType.bbox.value:
+    if annotation_type in [
+        AnnotationType.bbox.value,
+        AnnotationType.pose_estimation.value,
+    ]:
         width = points[0] - points[2]
         height = points[1] - points[3]
         return width * height


### PR DESCRIPTION
## 背景
- READMEには姿勢推定をサポートしていると記載があったが、実際に利用するとエラーが出てしまう状況だった
```
raise Exception(f"Unsupported annotation type: {annotation_type}")
Exception: Unsupported annotation type: pose_estimation
```

## やったこと
- pose_estimationでもareaの計算が行われるように修正した