### PR TITLE
sdkのexportに tags と object_type を追加

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4096,6 +4096,8 @@ class Client:
                         "name": obj["name"],
                         "annotations": obj["annotations"],
                         "customMetadata": obj["customMetadata"],
+                        "tags": obj["tags"],
+                        "object_type": obj["type"]
                     }
                     for obj in objects
                 ]


### PR DESCRIPTION
# 概要
このチケットの対応をしました。

https://github.com/fastlabel/fastlabel-application/issues/5844

# 関連PR
https://github.com/fastlabel/fastlabel-application/pull/6801

# 結果

ローカルでの出力結果は以下のようになりました。

```
[
    {
        "name": "md-20190924113402-5d89809aedb64.png",
        "annotations": [],
        "customMetadata": {
            "aaa": "qqq"
        },
        "tags": [
            "tuuuu",
            "weee"
        ],
        "object_type": "valid"
    }
]
```