### PR TITLE
COCO形式のnum_keypoints算出ロジックを修正

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -260,11 +260,28 @@ def __get_coco_annotation_keypoints(keypoints: list, category_keypoints: list) -
         if keypoint["value"]
     }
     for category_key in category_keypoints:
-        value = keypoint_values.get(category_key, [0, 0, 0])
+        value = keypoint_values.get(category_key)
+        if not value:
+            coco_annotation_keypoints.extend([0, 0, 0])
+            continue
         # Adjust fastlabel data definition to coco format
         visibility = 2 if value[2] == 1 else 1
         coco_annotation_keypoints.extend([value[0], value[1], visibility])
     return coco_annotation_keypoints
+
+
+COCO_KEYPOINT_V_INDEX = 2
+
+
+def __get_coco_num_keypoints(keypoints: list) -> int:
+    # https://cocodataset.org/#format-data
+    if not keypoints:
+        return 0
+    num_keypoints = 0
+    for keypoint in keypoints:
+        if keypoint["value"]:
+            num_keypoints += 1
+    return num_keypoints
 
 
 def __get_coco_annotation(
@@ -278,7 +295,7 @@ def __get_coco_annotation(
     rotation: int,
 ) -> dict:
     annotation = {}
-    annotation["num_keypoints"] = len(keypoints) if keypoints else 0
+    annotation["num_keypoints"] = __get_coco_num_keypoints(keypoints)
     annotation["keypoints"] = (
         __get_coco_annotation_keypoints(keypoints, category["keypoints"])
         if keypoints


### PR DESCRIPTION
## 背景
<!-- 簡単に対応した内容の概要や背景を記載してください。 -->
https://github.com/fastlabel/fastlabel-application/issues/7597 の対応

## リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->

## 対応内容
<!-- この PR の対応内容(やったこと)を記載してください。 -->
- coco形式変換時のnum_keypointsの算出ロジックを修正
  - 参考URL: https://cocodataset.org/#format-data
    > Each keypoint has a 0-indexed location x,y and a visibility flag v defined as v=0: not labeled (in which case x=y=0), v=1: labeled but not visible, and v=2: labeled and visible. A keypoint is considered visible if it falls inside the object segment. **"num_keypoints" indicates the number of labeled keypoints (v>0) for a given object** (many objects, e.g. crowds and small objects, will have num_keypoints=0).
  - 修正前はkeypointsのvisibility flagに関わらず、keypointsの合計数を出力していた
  - 削除されたキーポイントは除外し、非表示・表示されているキーポイントのみをカウントするよう修正

## 妥協点
<!-- この PR での妥協点(やれてないことなど)を記載してください。 -->

## UI before / after
<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を貼り付けてください。 -->

before
[sdk_coco_annotations_修正前.json](https://github.com/user-attachments/files/17130088/sdk_coco_annotations.json)

after
[sdk_coco_annotations_修正後.json](https://github.com/user-attachments/files/17130090/sdk_coco_annotations.json)

## テスト
<!-- local 環境や dev 環境でテストした項目を記載してください。 -->
- 削除されたキーポイントが存在する場合、num_keypointsにカウントされないこと

## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
