### PR TITLE
PascalVOCのオブジェクト出力順序を修正

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -684,9 +684,7 @@ def to_pascalvoc(project_type: str, tasks: list, output_dir: str) -> list:
             }
 
             if len(filtered_pascalvoc_objs) > 0:
-                voc["annotation"]["object"] = list(
-                    sorted(filtered_pascalvoc_objs, key=itemgetter("name"))
-                )
+                voc["annotation"]["object"] = filtered_pascalvoc_objs
 
             pascalvoc.append(voc)
     return pascalvoc


### PR DESCRIPTION
## 背景
<!-- 簡単に対応した内容の概要や背景を記載してください。 -->
https://github.com/orgs/fastlabel/projects/15/views/1?sliceBy%5Bvalue%5D=ctakigawa&pane=issue&itemId=82891444&issue=fastlabel%7Cfastlabel-application%7C7830
上記issueの対応

## リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->

## 対応内容
<!-- この PR の対応内容(やったこと)を記載してください。 -->
- PascalVOC出力時にオブジェクトの順序がアノテーションの追加順となるよう修正(PFの出力順序に合わせています)

## 妥協点
<!-- この PR での妥協点(やれてないことなど)を記載してください。 -->

## UI before / after
<!-- UI や振る舞いが変わる場合は before / after のスクショや動画を貼り付けてください。 -->
出力結果のbefore/after
https://github.com/fastlabel/fastlabel-python-sdk/pull/230#issuecomment-2408414735

## テスト
<!-- local 環境や dev 環境でテストした項目を記載してください。 -->
- PascalVOC出力時にオブジェクトの順序がアノテーションの追加順となっていること

## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
