### PR TITLE
自動アノテーション実行時のモデル特定のためalgorithm_typeパラメータを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2203,6 +2203,7 @@ The folder structure inside the ZIP file is as follows
 ```
 
 ### Export Camera Calibration and Image
+
 ```python
 appendix_data = client.get_appendix_data(
     project="YOUR_PROJECT_SLUG"
@@ -2217,6 +2218,7 @@ appendix_data = client.get_appendix_data(
 ```
 
 Result data
+
 ```
     [{
         id: uuid
@@ -3496,6 +3498,7 @@ auto_annotation_job = client.execute_auto_annotation_job(
     // Other built-in models require annotation class mapping.
     // See: https://fastlabel.notion.site/cf3f006766d742d5ae25ca4200fa19b4
     // If you want to use the custom model, please fill out model name.
+    algorithm_type: "object_detection", // optional, "object_detection", "ocr" or "image_classification"
     update_existing: False, // optional, default: False
     confidence_threshold: 0.4, // optional, default: 0.4
     use_tta: False, // optional, default: False

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4731,6 +4731,7 @@ class Client:
         self,
         project: str,
         model_name: str,
+        algorithm_type: str = None,
         update_existing: bool = False,
         confidence_threshold: float = 0.4,
         use_tta: bool = False,
@@ -4743,6 +4744,7 @@ class Client:
 
         project is slug of your project (Required).
         model_name is name of the model (Required). You can choose Japanese or English name.
+        algorithm_type is used to identify the model. algorithm_type can be 'object_detection' or 'ocr' or 'image_classification'(Optional).
         update_existing is whether to update existing annotations (Optional).
         confidence_threshold is a threshold of confidence (Optional).
         use_tta is whether to use test time augmentation (Optional).
@@ -4754,6 +4756,7 @@ class Client:
         payload = {
             "project": project,
             "modelName": model_name,
+            "algorithmType": algorithm_type,
             "updateExisting": update_existing,
             "confidenceThreshold": confidence_threshold,
             "useTTA": use_tta,


### PR DESCRIPTION
## サマリ
### 概要、背景

#236 の考慮漏れ修正対応

### （不具合の場合のみ） 発生原因

同名でアルゴリズムが異なるモデルの考慮が漏れており、モデル名で最初のモデルしか取得できておらず404エラーが返ってしまっていた。

## 対応内容
### やったこと

- ビルトインモデルを名前による取得処理を複数取得に変更
- プロジェクトで利用できるモデルを判定する関数をAPI側にも追加し、同名モデルから絞り込むように修正
- algorithm_typeパラメータを追加し、プロジェクト内で同名モデルが複数あっても特定できるように修正

### やれていないこと、妥協点

## UI/UX
### before

### after

## テスト
### 変更の意図に沿った基本動作が確認できている
- [x] SDKから植物病班の物体検出モデルで自動アノテーションができること
- [x] SDKから植物病班の画像分類モデルで自動アノテーションができること
- [x] SDKから腫瘍（乳がん）の物体検出モデルで自動アノテーションができること
- [x] SDKから腫瘍（乳がん）のインスタンスセグメンテーションモデルで自動アノテーションができること
- [x] SDKからナンバープレートのOCRモデルで自動アノテーションができること
- [x] SDKからナンバープレートの物体検出モデルで自動アノテーションができること
- [x] SDKからGPT-3.5 - 汎用のテキスト分類モデルで自動アノテーションができること
- [x] SDKからGPT-3.5 - 汎用のテキスト固有表現抽出モデルで自動アノテーションができること
### 関連する既存機能にデグレがないことを確認

### エッジケースや例外パターンの動作を確認



## 関連リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->


## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
