### PR TITLE
#8427 SDKで自動アノテーションの実行結果を取得できる

### DIFF
--- a/README.md
+++ b/README.md
@@ -3480,6 +3480,55 @@ training_job = client.execute_evaluation_job(
 
 ```
 
+### Get auto-annotation jobs
+
+Get auto-annotation jobs.
+
+```python
+def get_auto_annotation_jobs() -> list[dict]:
+    all_auto_annotation_jobs = []
+    offset = None
+    while True:
+        time.sleep(1)
+
+        auto_annotation_jobs = client.get_auto_annotation_jobs(project="YOUR_PROJECT_SLUG", offset=offset)
+        all_auto_annotation_jobs.extend(auto_annotation_jobs)
+
+        if len(auto_annotation_jobs) > 0:
+            offset = len(all_auto_annotation_jobs)
+        else:
+            break
+    return all_auto_annotation_jobs
+
+```
+
+#### Response
+
+Example of a single auto-annotation job.
+
+```python
+
+[
+    {
+        'audioSeconds': 0,
+        'autoAnnotationType': 'image_bbox',
+        'completedAt': '2024-09-24T03:27:41.000Z',
+        'contentCount': 1000,
+        'createdAt': '2024-09-24T03:14:26.607Z',
+        'duration': 793,
+        'id': 'YOUR_AUTO_ANNOTATION_JOB_ID',
+        'modelName': 'Computer Vision - 汎用',
+        'msgCode': 'none',
+        'status': 'completed',
+        'taskAnnotationCount': 2598,
+        'updatedAt': '2024-09-24T03:27:40.914Z',
+        'userName': 'USER_NAME',
+        'version': 1
+    }
+]
+
+```
+
 ### Execute auto-annotation job
 
 Execute auto-annotation job.

--- a/examples/get_auto_annotation_jobs.py
+++ b/examples/get_auto_annotation_jobs.py
@@ -1,0 +1,10 @@
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+auto_annotation_jobs = client.get_auto_annotation_jobs(
+    project="YOUR_PROJECT_SLUG"
+)
+pprint(auto_annotation_jobs)

--- a/examples/get_auto_annotation_jobs.py
+++ b/examples/get_auto_annotation_jobs.py
@@ -4,7 +4,5 @@ import fastlabel
 
 client = fastlabel.Client()
 
-auto_annotation_jobs = client.get_auto_annotation_jobs(
-    project="YOUR_PROJECT_SLUG"
-)
+auto_annotation_jobs = client.get_auto_annotation_jobs(project="YOUR_PROJECT_SLUG")
 pprint(auto_annotation_jobs)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4727,6 +4727,37 @@ class Client:
             payload={key: value for key, value in payload.items() if value is not None},
         )
 
+    def get_auto_annotation_jobs(
+        self,
+        project: str,
+        offset: int = None,
+        limit: int = 1000,
+    ) -> list:
+        """
+        Returns a list of auto-annotation jobs.
+        Returns up to 1000 at a time, to get more, set offset as the starting position
+        to fetch.
+        project is slug of your project (Required).
+        offset is the starting position number to fetch (Optional).
+        limit is the max number to fetch (Optional).
+        """
+        if project is None:
+            raise FastLabelInvalidException(
+                "Project is required.", 422
+            )
+        if limit > 1000:
+            raise FastLabelInvalidException(
+                "Limit must be less than or equal to 1000.", 422
+            )
+        endpoint = "auto-annotations"
+        params = {"project": project}
+        if offset:
+            params["offset"] = offset
+        if limit:
+            params["limit"] = limit
+
+        return self.api.get_request(endpoint, params=params)
+
     def execute_auto_annotation_job(
         self,
         project: str,

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4742,9 +4742,7 @@ class Client:
         limit is the max number to fetch (Optional).
         """
         if project is None:
-            raise FastLabelInvalidException(
-                "Project is required.", 422
-            )
+            raise FastLabelInvalidException("Project is required.", 422)
         if limit > 1000:
             raise FastLabelInvalidException(
                 "Limit must be less than or equal to 1000.", 422


### PR DESCRIPTION
## サマリ
### 概要、背景

#8427 の対応

### （不具合の場合のみ） 発生原因


## 対応内容
### やったこと

SDKから指定されたプロジェクトの自動アノテーション実行履歴を取得できるようにした。

### やれていないこと、妥協点

## UI/UX
### before

### after

## テスト
### 変更の意図に沿った基本動作が確認できている
- [x] 指定したプロジェクトの自動アノテーション実行履歴が取得できること
- [x] limitパラメーターに1000より大きい数値を指定して実行した場合エラーになること
- [x] projectパラメーター未指定で実行した場合エラーになること
- [x] 読み取り専用のAPIアクセストークンでも自動アノテーション実行履歴が取得できること
### 関連する既存機能にデグレがないことを確認

### エッジケースや例外パターンの動作を確認


## 関連リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->


## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
