### PR TITLE
debug enable to export tasks by yolo format

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -540,7 +540,7 @@ def __coco2yolo_rect(
 
         obj = [category_index, x, y, w, h]
         objs.append(" ".join(obj))
-        return obj
+    return objs
 
 
 def __coco2yolo_segmentation(


### PR DESCRIPTION
# issue
- https://github.com/fastlabel/fastlabel-python-sdk/issues/240

## 概要
[YOLO を segmentation に対応する修正](https://github.com/fastlabel/fastlabel-python-sdk/pull/227) で、ループ終了後にリターンをすべきところで、ループ中にリターンをしてしまっていた

## テスト
- [x] 正しいYOLO形式で出力できる
**before**
```text
0
0.3849218
0.7038359
0.1395625
0.0954843
```
[photo_2_2024-03-27_01-35-51_jpg.rf.2a5dec55c5c646d26d660dfdd237d2e7.txt](https://github.com/user-attachments/files/18244670/photo_2_2024-03-27_01-35-51_jpg.rf.2a5dec55c5c646d26d660dfdd237d2e7.txt)



**after**
```text
0 0.3849218 0.7038359 0.1395625 0.0954843
0 0.6371171 0.3432968 0.2228281 0.2289375
1 0.2361718 0.3145234 0.2975 0.2962656
1 0.7473046 0.7338359 0.3158593 0.2950468
```

[photo_2_2024-03-27_01-35-51_jpg.rf.2a5dec55c5c646d26d660dfdd237d2e7.txt](https://github.com/user-attachments/files/18244672/photo_2_2024-03-27_01-35-51_jpg.rf.2a5dec55c5c646d26d660dfdd237d2e7.txt)

- [x] セグメンテーションも問題なく出力できる
