### PR TITLE
export_cocoでキーポイント付きの矩形のkeypointが出力されるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -2956,7 +2956,7 @@ Export with specifying output directory and file name.
 client.export_coco(project="YOUR_PROJECT_SLUG", tasks=tasks, output_dir="YOUR_DIRECTROY", output_file_name="YOUR_FILE_NAME")
 ```
 
-If you would like to export pose estimation type annotations, please pass annotations.
+If you would like to export pose estimation type annotations or bbox type annotations with keypoints, please pass annotations.
 
 ```python
 project_slug = "YOUR_PROJECT_SLUG"

--- a/examples/export_coco.py
+++ b/examples/export_coco.py
@@ -2,7 +2,7 @@ import fastlabel
 
 client = fastlabel.Client()
 
-project_slug = "issue-9274"
+project_slug = "YOUR_PROJECT_SLUG"
 tasks = client.get_image_tasks(project=project_slug)
 annotations = client.get_annotations(project=project_slug)
 

--- a/examples/export_coco.py
+++ b/examples/export_coco.py
@@ -1,0 +1,9 @@
+import fastlabel
+
+client = fastlabel.Client()
+
+project_slug = "issue-9274"
+tasks = client.get_image_tasks(project=project_slug)
+annotations = client.get_annotations(project=project_slug)
+
+client.export_coco(project=project_slug, tasks=tasks, annotations=annotations, output_dir="./export_coco/")

--- a/examples/export_coco.py
+++ b/examples/export_coco.py
@@ -6,4 +6,9 @@ project_slug = "issue-9274"
 tasks = client.get_image_tasks(project=project_slug)
 annotations = client.get_annotations(project=project_slug)
 
-client.export_coco(project=project_slug, tasks=tasks, annotations=annotations, output_dir="./export_coco/")
+client.export_coco(
+    project=project_slug,
+    tasks=tasks,
+    annotations=annotations,
+    output_dir="./export_coco/",
+)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -3136,7 +3136,7 @@ class Client:
     ) -> None:
         """
         Convert tasks to COCO format and export as a file.
-        If you pass annotations, you can export Pose Estimation type annotations.
+        If you pass annotations, you can export Pose Estimation type annotations or Bbox type annotations with keypoints.
 
         project is slug of your project (Required).
         tasks is a list of tasks (Required).

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -180,7 +180,10 @@ def __get_coco_categories(tasks: list, annotations: list) -> list:
         coco_skeleton = []
         coco_keypoints = []
         coco_keypoint_colors = []
-        if annotation["type"] in [AnnotationType.pose_estimation.value, AnnotationType.bbox.value]:
+        if annotation["type"] in [
+            AnnotationType.pose_estimation.value,
+            AnnotationType.bbox.value,
+        ]:
             keypoints = annotation["keypoints"]
             for keypoint in keypoints:
                 coco_keypoints.append(keypoint["key"])

--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -180,7 +180,7 @@ def __get_coco_categories(tasks: list, annotations: list) -> list:
         coco_skeleton = []
         coco_keypoints = []
         coco_keypoint_colors = []
-        if annotation["type"] == AnnotationType.pose_estimation.value:
+        if annotation["type"] in [AnnotationType.pose_estimation.value, AnnotationType.bbox.value]:
             keypoints = annotation["keypoints"]
             for keypoint in keypoints:
                 coco_keypoints.append(keypoint["key"])


### PR DESCRIPTION
## サマリ
### 概要、背景

https://github.com/fastlabel/fastlabel-application/issues/9274

### （不具合の場合のみ） 発生原因

## 対応内容
### やったこと

COCO出力時にキーポイント付き矩形アノテーションのキーポイント情報も出力されるようにしました。
姿勢推定アノテーションと同様、キーポイント付き矩形アノテーションを出力したい場合は、export_cocoの引数にanottationsを渡す仕様になっています。

### やれていないこと、妥協点

## UI/UX
### before

### after

## テスト
### 変更の意図に沿った基本動作が確認できている
- [x] SDKでexport_cocoを実行して、キーポイント情報が含まれたCOCO形式のannotations.jsonが出力されること
- [x] WebでエクスポートしたCOCO出力形式のannotations.jsonと差分がないこと
### 関連する既存機能にデグレがないことを確認
- [x] 姿勢推定と矩形以外のアノテーション
  - [x] 多角形アノテーションがCOCO形式で出力できること
    - [x] WebでエクスポートしたCOCO出力形式のannotations.jsonと差分がないこと
  - [x] セグメンテーションアノテーションがCOCO形式で出力できること
    - [x] WebでエクスポートしたCOCO出力形式のannotations.jsonと差分がないこと
### エッジケースや例外パターンの動作を確認

## 関連リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->


## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
