### PR TITLE
ビルドに必要なsetuptools v61.0.0を指定してインストール

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install setuptools>=61.0.0 wheel
 
       - name: Build
         run: |


### PR DESCRIPTION
0.19.2のリリース時に以下のビルドエラーが発生したため、必要なsetuptoolsをバージョン指定してインストールするように修正しました。

> ERROR: setuptools==56.0.0 is used in combination with setuptools-scm>=8.x
Your build configuration is incomplete and previously worked by accident!
setuptools-scm requires setuptools>=61

ビルドで使用されている`setuptools-scm`がバージョンアップされ、`setuptools`のバージョン要件に適合しなくなったと思われます。

https://github.com/fastlabel/fastlabel-python-sdk/actions/runs/13915898311/job/38938829714
