### PR TITLE
#9301 find_dataset_object, delete_dataset_objectに渡すobject_nameに/が含まれていると404エラーになる

### DIFF
--- a/examples/delete_dataset_object.py
+++ b/examples/delete_dataset_object.py
@@ -3,5 +3,5 @@ import fastlabel
 client = fastlabel.Client()
 
 client.delete_dataset_object(
-    dataset_id="YOUR_DATASET_OBJECT_ID", object_name="YOUR_OBJECT_NAME"
+    dataset_id="YOUR_DATASET_ID", object_name="YOUR_OBJECT_NAME"
 )

--- a/examples/find_dataset_object.py
+++ b/examples/find_dataset_object.py
@@ -5,6 +5,6 @@ import fastlabel
 client = fastlabel.Client()
 
 dataset_object = client.find_dataset_object(
-    dataset_id="YOUR_DATASET_OBJECT_ID", object_name="YOUR_OBJECT_NAME"
+    dataset_id="YOUR_DATASET_ID", object_name="YOUR_OBJECT_NAME"
 )
 pprint(dataset_object)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
@@ -11,7 +12,6 @@ import cv2
 import numpy as np
 import requests
 import xmltodict
-import urllib.parse
 from PIL import Image, ImageColor, ImageDraw
 
 from fastlabel import const, converters, utils

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4253,7 +4253,9 @@ class Client:
                 "only use specify one of revisionId or version.", 400
             )
         encoded_object_name = urllib.parse.quote(object_name, safe="")
-        endpoint = "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
+        endpoint = (
+            "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
+        )
         params = {}
         if revision_id:
             params["revisionId"] = revision_id
@@ -4477,7 +4479,9 @@ class Client:
         Delete a dataset object.
         """
         encoded_object_name = urllib.parse.quote(object_name, safe="")
-        endpoint = "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
+        endpoint = (
+            "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
+        )
         self.api.delete_request(endpoint)
 
     def update_aws_s3_storage(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -11,6 +11,7 @@ import cv2
 import numpy as np
 import requests
 import xmltodict
+import urllib.parse
 from PIL import Image, ImageColor, ImageDraw
 
 from fastlabel import const, converters, utils
@@ -4251,7 +4252,8 @@ class Client:
             raise FastLabelInvalidException(
                 "only use specify one of revisionId or version.", 400
             )
-        endpoint = "datasets-v2/" + dataset_id + "/objects/" + object_name
+        encoded_object_name = urllib.parse.quote(object_name, safe="")
+        endpoint = "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
         params = {}
         if revision_id:
             params["revisionId"] = revision_id
@@ -4474,7 +4476,8 @@ class Client:
         """
         Delete a dataset object.
         """
-        endpoint = "datasets-v2/" + dataset_id + "/objects/" + object_name
+        encoded_object_name = urllib.parse.quote(object_name, safe="")
+        endpoint = "dataset-objects-v2/" + dataset_id + "/objects/" + encoded_object_name
         self.api.delete_request(endpoint)
 
     def update_aws_s3_storage(


### PR DESCRIPTION
## サマリ
### 概要、背景

#9301 

### （不具合の場合のみ） 発生原因

find_dataset_object, delete_dataset_objectのobjectName引数に`/`が含まれていると、URLとして認識されてしまい404エラーになってしまっていました。

## 対応内容
### やったこと

- find_dataset_object, delete_dataset_objectでAPIリクエスト前にobjectNameをエンコードするように修正しました。
- endpoint変更
- exampleの修正

### やれていないこと、妥協点

## UI/UX
### before

### after

## テスト
### 変更の意図に沿った基本動作が確認できている
- [x] find_dataset_objectメソッドが実行できること
- [x] delete_dataset_objectメソッドが実行できること

### 関連する既存機能にデグレがないことを確認

### エッジケースや例外パターンの動作を確認

## 関連リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->


## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->
