### PR TITLE
API キーを Client の初期化時に渡せるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ import fastlabel
 client = fastlabel.Client()
 ```
 
+Or initialize with API Key directly.
+
+```python
+import fastlabel
+client = fastlabel.Client("YOUR_ACCESS_TOKEN")
+```
+
 ### Limitation
 
 API is allowed to call 10000 times per 10 minutes. If you create/delete a large size of tasks, please wait a second for every requests.

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -41,8 +41,8 @@ logging.basicConfig(
 class Client:
     api = None
 
-    def __init__(self):
-        self.api = Api()
+    def __init__(self, access_token: Optional[str] = None):
+        self.api = Api(access_token=access_token)
 
     # Task Find
 

--- a/fastlabel/api.py
+++ b/fastlabel/api.py
@@ -1,5 +1,5 @@
 import os
-from typing import Union
+from typing import Optional, Union
 
 import requests
 
@@ -11,12 +11,13 @@ class Api:
 
     access_token = None
 
-    def __init__(self):
-        if os.environ.get("FASTLABEL_API_URL"):
-            self.base_url = os.environ.get("FASTLABEL_API_URL")
-        if not os.environ.get("FASTLABEL_ACCESS_TOKEN"):
+    def __init__(self, access_token: Optional[str] = None):
+        if api_url := os.environ.get("FASTLABEL_API_URL"):
+            self.base_url = api_url
+        access_token = access_token or os.environ.get("FASTLABEL_ACCESS_TOKEN")
+        if not access_token:
             raise ValueError("FASTLABEL_ACCESS_TOKEN is not configured.")
-        self.access_token = "Bearer " + os.environ.get("FASTLABEL_ACCESS_TOKEN")
+        self.access_token = "Bearer " + access_token
 
     def get_request(self, endpoint: str, params=None) -> Union[dict, list]:
         """Makes a get request to an endpoint.


### PR DESCRIPTION
今までは環境変数経由でしか渡せなかったAPIキーを、Client の初期化時にも渡せるように修正しました。
両方から渡された場合は初期化時のAPIキーが使われます。

今までは環境変数経由のみだったため、別のAPIキーを使い分けるケース（ワークスペースを跨いだ処理）では環境変数を変えてClient を作り直す、などの複雑なことをしないといけませんでした。
今回のこの処理で、コンストラクト時に渡せるようになるので、シンプルになります。

↓藤繁さんからも、賛同いただいています。
https://fastlabel.slack.com/archives/C058HK65BND/p1750818698971999?thread_ts=1750817885.721389&cid=C058HK65BND