### PR TITLE
fix ポリゴンをYOLOで出力した時の座標情報が4点しか出ない

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -656,9 +656,22 @@ def __get_yolo_annotation(data: dict) -> dict:
     dh = 1.0 / data["height"]
     if annotation_type == AnnotationType.segmentation.value:
         return __segmentation2yolo(value, classes, dw, dh, points)
+    elif annotation_type == AnnotationType.polygon.value:
+        return _polygon2yolo(value, classes, dw, dh, points)
     else:
         bbox = __to_bbox(annotation_type, points)
         return __bbox2yolo(value, classes, dw, dh, bbox)
+
+
+def _polygon2yolo(value: str, classes: list, dw: float, dh: float, points: list):
+    category_index = str(classes.index(value))
+    # polygon の points は [x1, y1, x2, y2, ...] の形式
+    # 各座標を正規化して一つのリストにまとめる
+    normalized_coords = [
+        str(_truncate(points[i] * (dw if i % 2 == 0 else dh), 7))
+        for i in range(len(points))
+    ]
+    return [" ".join([category_index] + normalized_coords)]
 
 
 def __segmentation2yolo(value: str, classes: list, dw: float, dh: float, points: list):


### PR DESCRIPTION
## 概要
polygon タイプのアノテーションを YOLO 形式でエクスポートする際、4点のバウンディングボックスに変換されていた問題を修正しました。

## 問題
- polygon (多角形) プロジェクトで YOLO 形式でエクスポートすると、座標情報が4点（中心x, 中心y, 幅, 高さ）しか出力されない
- 本来は polygon の全頂点座標が出力されるべき

## 修正内容
1. `_polygon2yolo` 関数を新規追加
   - polygon の points ([x1, y1, x2, y2, ...]) を YOLO 形式に正しく変換
   - 全頂点座標を正規化して出力

2. `__get_yolo_annotation` 関数を修正
   - polygon タイプの場合は `_polygon2yolo` 関数を使用するように変更
   - segmentation と同様に全座標を出力

## 関連 Issue
fastlabel/fastlabel-application#10004

## テスト
polygon タイプのアノテーションが YOLO 形式で全頂点座標として正しくエクスポートされることを確認してください。