### PR TITLE
feat: copy_projectメソッドに名前とスラッグのオプションパラメータを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2528,10 +2528,18 @@ client.delete_project(project_id="YOUR_PROJECT_ID")
 
 ### Copy Project
 
-Copy a project.
+Copy a project. You can optionally specify a custom name and slug for the copied project.
 
 ```python
+# Copy project with default name/slug
 project_id = client.copy_project(project_id="YOUR_PROJECT_ID")
+
+# Copy project with custom name and slug
+project_id = client.copy_project(
+    project_id="YOUR_PROJECT_ID",
+    project_name="Custom Project Name",
+    project_slug="custom-project-slug"
+)
 ```
 
 ### Update Project Metadata

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4105,13 +4105,25 @@ class Client:
         endpoint = "projects/" + project_id
         self.api.delete_request(endpoint)
 
-    def copy_project(self, project_id: str) -> None:
+    def copy_project(
+        self,
+        project_id: str,
+        project_name: Optional[str] = None,
+        project_slug: Optional[str] = None,
+    ) -> None:
         """
         Copy a project.
         """
-        payload = {"id": project_id}
         endpoint = "projects/copy"
-        return self.api.post_request(endpoint, payload=payload)
+        payload = {"id": project_id}
+        if project_name:
+            payload["name"] = project_name
+        if project_slug:
+            payload["slug"] = project_slug
+        return self.api.post_request(
+            endpoint,
+            payload=payload,
+        )
 
     def update_project_metadata(
         self,


### PR DESCRIPTION
## 概要
- `copy_project`メソッドにオプショナルな`project_name`と`project_slug`パラメータを追加
- READMEドキュメントを更新し、基本的な使用方法と高度な使用方法の両方の例を追加
- 既存のコードとの完全な後方互換性を維持

## 変更内容
- `fastlabel/__init__.py`の`copy_project`メソッドを修正し、オプショナルな名前とスラッグパラメータを受け入れるように変更
- READMEを更新し、新機能を示す明確な例を追加
- コピーされたプロジェクトの詳細をカスタマイズしたいユーザーのために、より柔軟なメソッドシグネチャに改善


## テスト計画
- [x] 既存のcopy_project呼び出しが引き続き動作することを確認（後方互換性）

<img width="789" height="142" alt="Screenshot 2025-12-03 at 14 12 28" src="https://github.com/user-attachments/assets/46edd19e-2e6d-480d-8fc3-7190512faf8c" />


- [x] カスタム名とスラッグの両方のパラメータを使用したcopy_projectのテスト


<img width="1172" height="166" alt="Screenshot 2025-12-03 at 12 36 03" src="https://github.com/user-attachments/assets/1cf286ad-6911-4bfd-a3cf-2f800edce12f" />
<img width="1456" height="309" alt="Screenshot 2025-12-03 at 12 36 13" src="https://github.com/user-attachments/assets/7f0c485c-bf58-4387-97f4-0d2ec4693017" />


- [x] バリデーションエラーが発生する

<img width="1226" height="360" alt="Screenshot 2025-12-03 at 12 35 08" src="https://github.com/user-attachments/assets/fc7e0652-629d-4aa4-ba0c-4851015cc8ed" />
<img width="1328" height="434" alt="Screenshot 2025-12-03 at 12 35 35" src="https://github.com/user-attachments/assets/99780e92-41df-498f-ba8f-166ecadcf98d" />


🤖 Generated with [Claude Code](https://claude.ai/code)