### PR TITLE
feat: Allow tasks with zero height/width in COCO and Pascal VOC converters

### DIFF
--- a/fastlabel/converters.py
+++ b/fastlabel/converters.py
@@ -34,9 +34,6 @@ def to_coco(
     annotation_id = 0
     image_index = 0
     for task in tasks:
-        if task["height"] == 0 or task["width"] == 0:
-            continue
-
         if is_video_project_type(project_type):
             image_file_names = _export_image_files_for_video_task(
                 task, str((Path(output_dir) / "images").resolve())
@@ -726,9 +723,6 @@ def _truncate(n, decimals=0) -> float:
 def to_pascalvoc(project_type: str, tasks: list, output_dir: str) -> list:
     pascalvoc = []
     for task in tasks:
-        if task["height"] == 0 or task["width"] == 0:
-            continue
-
         if is_video_project_type(project_type):
             image_file_names = _export_image_files_for_video_task(
                 task, str((Path(output_dir) / "images").resolve())

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,201 @@
+from fastlabel import converters
+
+
+class TestToCoco:
+    """Tests for to_coco converter function."""
+
+    def test_to_coco_with_zero_height_task(self, tmp_path):
+        """Test that tasks with height=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 0,
+                "width": 100,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "cat",
+                        "points": [10, 10, 50, 50],
+                        "color": "#FF0000",
+                    }
+                ],
+            },
+            {
+                "name": "image2.jpg",
+                "height": 100,
+                "width": 100,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "cat",
+                        "points": [10, 10, 50, 50],
+                        "color": "#FF0000",
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_coco(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result["images"]) == 2
+        assert result["images"][0]["height"] == 0
+        assert result["images"][1]["height"] == 100
+
+    def test_to_coco_with_zero_width_task(self, tmp_path):
+        """Test that tasks with width=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 100,
+                "width": 0,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "dog",
+                        "points": [10, 10, 50, 50],
+                        "color": "#00FF00",
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_coco(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result["images"]) == 1
+        assert result["images"][0]["width"] == 0
+
+    def test_to_coco_with_zero_dimensions_task(self, tmp_path):
+        """Test that tasks with both height=0 and width=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 0,
+                "width": 0,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "bird",
+                        "points": [10, 10, 50, 50],
+                        "color": "#0000FF",
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_coco(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result["images"]) == 1
+        assert result["images"][0]["height"] == 0
+        assert result["images"][0]["width"] == 0
+
+
+class TestToPascalVoc:
+    """Tests for to_pascalvoc converter function."""
+
+    def test_to_pascalvoc_with_zero_height_task(self, tmp_path):
+        """Test that tasks with height=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 0,
+                "width": 100,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "cat",
+                        "points": [10, 10, 50, 50],
+                        "attributes": [],
+                    }
+                ],
+            },
+            {
+                "name": "image2.jpg",
+                "height": 100,
+                "width": 100,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "cat",
+                        "points": [10, 10, 50, 50],
+                        "attributes": [],
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_pascalvoc(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result) == 2
+        assert result[0]["annotation"]["size"]["height"] == 0
+        assert result[1]["annotation"]["size"]["height"] == 100
+
+    def test_to_pascalvoc_with_zero_width_task(self, tmp_path):
+        """Test that tasks with width=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 100,
+                "width": 0,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "dog",
+                        "points": [10, 10, 50, 50],
+                        "attributes": [],
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_pascalvoc(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result) == 1
+        assert result[0]["annotation"]["size"]["width"] == 0
+
+    def test_to_pascalvoc_with_zero_dimensions_task(self, tmp_path):
+        """Test that tasks with both height=0 and width=0 are included in output."""
+        tasks = [
+            {
+                "name": "image1.jpg",
+                "height": 0,
+                "width": 0,
+                "annotations": [
+                    {
+                        "type": "bbox",
+                        "value": "bird",
+                        "points": [10, 10, 50, 50],
+                        "attributes": [],
+                    }
+                ],
+            },
+        ]
+
+        result = converters.to_pascalvoc(
+            project_type="image_bbox",
+            tasks=tasks,
+            output_dir=str(tmp_path),
+        )
+
+        assert len(result) == 1
+        assert result[0]["annotation"]["size"]["height"] == 0
+        assert result[0]["annotation"]["size"]["width"] == 0


### PR DESCRIPTION
## Summary
- `to_coco` と `to_pascalvoc` 関数で `height=0` または `width=0` のタスクがスキップされる問題を修正
- YOLO形式と異なり、これらの形式では除算が不要なため0値でも安全に出力可能

## Changes
- `converters.py`: `to_coco` と `to_pascalvoc` から早期リターンチェックを削除
- `tests/test_converters.py`: 6つのテストケースを追加

## Test plan
- [x] `pytest tests/test_converters.py` で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)