### PR TITLE
feat: get_project_comments メソッドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2721,10 +2721,10 @@ Example of a comment object
 
 ### Get Project Comments
 
-Get comments of a project. Returns up to 1000 comments per request. Use `offset` for pagination.
+Get comment threads of a project. Returns up to 1000 comment threads per request. Use `offset` for pagination.
 
 ```python
-comments = client.get_project_comments(project="YOUR_PROJECT_SLUG")
+comment_threads = client.get_project_comments(project="YOUR_PROJECT_SLUG")
 ```
 
 #### Parameters
@@ -2732,42 +2732,40 @@ comments = client.get_project_comments(project="YOUR_PROJECT_SLUG")
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
 | project | str | Yes | Project slug |
-| status | str | No | Filter by status |
-| external_status | str | No | Filter by external status |
-| tags | list | No | Filter by tags |
+| status | str | No | Filter by task status |
+| external_status | str | No | Filter by task external status |
+| tags | list | No | Filter by task tags |
 | issue_category_id | str | No | Filter by issue category ID |
 | offset | int | No | Offset for pagination |
-| limit | int | No | Number of comments to retrieve (default: 100, max: 1000) |
+| limit | int | No | Number of comment threads to retrieve (default: 100, max: 1000) |
 
 ### Response
 
-Example of a comment object
+Example of a comment thread object
 
 ```python
 {
-    "id": "YOUR_COMMENT_ID",
-    "taskId": "YOUR_TASK_ID",
-    "contentId": "YOUR_CONTENT_ID",
-    "type": "text",
-    "isResolved": False,
-    "points": [185.98, 86.55],
-    "scale": 0,
-    "frame": 0,
-    "status": "todo",
-    "priority": 0,
-    "taskAnnotationId": None,
-    "issueCategoryId": None,
-    "color": None,
-    "threads": [
-        {
-            "id": "YOUR_THREAD_ID",
-            "text": "comment text",
-            "createdAt": "2026-03-03T03:51:55.247Z",
-            "updatedAt": "2026-03-03T03:51:55.247Z",
-        },
-    ],
-    "createdAt": "2026-03-03T03:51:55.240Z",
-    "updatedAt": "2026-03-03T03:51:55.240Z",
+    "id": "YOUR_THREAD_ID",
+    "text": "comment text",
+    "comment": {
+        "id": "YOUR_COMMENT_ID",
+        "taskId": "YOUR_TASK_ID",
+        "contentId": "YOUR_CONTENT_ID",
+        "type": "text",
+        "isResolved": False,
+        "points": [185.98, 86.55],
+        "scale": 0,
+        "frame": 0,
+        "status": "todo",
+        "priority": 0,
+        "taskAnnotationId": None,
+        "issueCategoryId": None,
+        "color": None,
+        "createdAt": "2026-03-03T03:51:55.240Z",
+        "updatedAt": "2026-03-03T03:51:55.240Z",
+    },
+    "createdAt": "2026-03-03T03:51:55.247Z",
+    "updatedAt": "2026-03-03T03:51:55.247Z",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2719,6 +2719,58 @@ Example of a comment object
 }
 ```
 
+### Get Project Comments
+
+Get comments of a project. Returns up to 1000 comments per request. Use `offset` for pagination.
+
+```python
+comments = client.get_project_comments(project="YOUR_PROJECT_SLUG")
+```
+
+#### Parameters
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| project | str | Yes | Project slug |
+| status | str | No | Filter by status |
+| external_status | str | No | Filter by external status |
+| tags | list | No | Filter by tags |
+| issue_category_id | str | No | Filter by issue category ID |
+| offset | int | No | Offset for pagination |
+| limit | int | No | Number of comments to retrieve (default: 100, max: 1000) |
+
+### Response
+
+Example of a comment object
+
+```python
+{
+    "id": "YOUR_COMMENT_ID",
+    "taskId": "YOUR_TASK_ID",
+    "contentId": "YOUR_CONTENT_ID",
+    "type": "text",
+    "isResolved": False,
+    "points": [185.98, 86.55],
+    "scale": 0,
+    "frame": 0,
+    "status": "todo",
+    "priority": 0,
+    "taskAnnotationId": None,
+    "issueCategoryId": None,
+    "color": None,
+    "threads": [
+        {
+            "id": "YOUR_THREAD_ID",
+            "text": "comment text",
+            "createdAt": "2026-03-03T03:51:55.247Z",
+            "updatedAt": "2026-03-03T03:51:55.247Z",
+        },
+    ],
+    "createdAt": "2026-03-03T03:51:55.240Z",
+    "updatedAt": "2026-03-03T03:51:55.240Z",
+}
+```
+
 ## Project
 
 ### Create Project

--- a/README.md
+++ b/README.md
@@ -2739,7 +2739,7 @@ comment_threads = client.get_project_comments(project="YOUR_PROJECT_SLUG")
 | offset | int | No | Offset for pagination |
 | limit | int | No | Number of comment threads to retrieve (default: 100, max: 1000) |
 
-### Response
+#### Response
 
 Example of a comment thread object
 

--- a/examples/get_project_comments.py
+++ b/examples/get_project_comments.py
@@ -4,5 +4,5 @@ import fastlabel
 
 client = fastlabel.Client()
 
-comments = client.get_project_comments(project="YOUR_PROJECT_SLUG")
-pprint(comments)
+comment_threads = client.get_project_comments(project="YOUR_PROJECT_SLUG")
+pprint(comment_threads)

--- a/examples/get_project_comments.py
+++ b/examples/get_project_comments.py
@@ -1,0 +1,8 @@
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+comments = client.get_project_comments(project="YOUR_PROJECT_SLUG")
+pprint(comments)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -5274,11 +5274,11 @@ class Client:
         endpoint = "comments"
         params = {"project": project}
         if status:
-            params["status"] = status
+            params["taskStatus"] = status
         if external_status:
-            params["externalStatus"] = external_status
+            params["taskExternalStatus"] = external_status
         if tags:
-            params["tags"] = tags
+            params["taskTags"] = tags
         if issue_category_id:
             params["issueCategoryId"] = issue_category_id
         if offset:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -5257,6 +5257,36 @@ class Client:
             params["limit"] = limit
         return self.api.get_request(endpoint, params=params)
 
+    def get_project_comments(
+        self,
+        project: str,
+        status: str = None,
+        external_status: str = None,
+        tags: list = None,
+        issue_category_id: str = None,
+        offset: int = None,
+        limit: int = 100,
+    ) -> list:
+        if limit > 1000:
+            raise FastLabelInvalidException(
+                "Limit must be less than or equal to 1000.", 422
+            )
+        endpoint = "comments"
+        params = {"project": project}
+        if status:
+            params["status"] = status
+        if external_status:
+            params["externalStatus"] = external_status
+        if tags:
+            params["tags"] = tags
+        if issue_category_id:
+            params["issueCategoryId"] = issue_category_id
+        if offset:
+            params["offset"] = offset
+        if limit:
+            params["limit"] = limit
+        return self.api.get_request(endpoint, params=params)
+
     def mask_to_fastlabel_segmentation_points(
         self, mask_image: Union[str, np.ndarray]
     ) -> List[List[List[int]]]:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -5248,9 +5248,7 @@ class Client:
                 "Limit must be less than or equal to 1000.", 422
             )
         endpoint = "comments"
-        params = {"project": project}
-        if task_id:
-            params["taskId"] = task_id
+        params = {"project": project, "taskId": task_id}
         if offset:
             params["offset"] = offset
         if limit:
@@ -5271,7 +5269,7 @@ class Client:
             raise FastLabelInvalidException(
                 "Limit must be less than or equal to 1000.", 422
             )
-        endpoint = "comments"
+        endpoint = "comments/threads"
         params = {"project": project}
         if status:
             params["taskStatus"] = status

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -5249,9 +5249,9 @@ class Client:
             )
         endpoint = "comments"
         params = {"project": project, "taskId": task_id}
-        if offset:
+        if offset is not None:
             params["offset"] = offset
-        if limit:
+        if limit is not None:
             params["limit"] = limit
         return self.api.get_request(endpoint, params=params)
 
@@ -5279,9 +5279,9 @@ class Client:
             params["taskTags"] = tags
         if issue_category_id:
             params["issueCategoryId"] = issue_category_id
-        if offset:
+        if offset is not None:
             params["offset"] = offset
-        if limit:
+        if limit is not None:
             params["limit"] = limit
         return self.api.get_request(endpoint, params=params)
 


### PR DESCRIPTION
## サマリ
### 概要、背景

fastlabel/fastlabel-application#10863 対応のSDK実装。プロジェクト単位でコメント一覧を取得できる `get_project_comments` メソッドを追加。

### （不具合の場合のみ） 発生原因


## 対応内容
### やったこと

`get_project_comments` メソッドを追加

```python
client.get_project_comments(
    project="my-project-slug",
    status="approved",           # タスクのステータスフィルタ（省略可）
    external_status="approved",  # タスクの外部ステータスフィルタ（省略可）
    tags=["tag1", "tag2"],       # タグフィルタ（省略可）
    issue_category_id="uuid",    # イシュー分類フィルタ（省略可）
    offset=0,                    # ページネーション（省略可）
    limit=100,                   # 最大1000（省略可）
)
```

API側の変更（fastlabel-application PR #10927）に対応。`taskId` を省略してプロジェクト全体のコメントを取得する。

### やれていないこと、妥協点


## UI/UX
### before

### after


## テスト
### 変更の意図に沿った基本動作が確認できている
- [ ] `get_project_comments(project="slug")` でコメント一覧が取得できる
- [ ] フィルタパラメータが正しくAPIに渡される
### 関連する既存機能にデグレがないことを確認
- [ ] 既存の `get_task_comments` に変更がないこと
### エッジケースや例外パターンの動作を確認
- [ ] limit > 1000 で例外が発生すること


## 関連リンク
<!-- - [Design Docs](url) -->
<!-- - [Slack](url) -->

- fastlabel/fastlabel-application#10927

## 補足
<!-- その他補足事項があれば、記載してください。マージのタイミングや困っていることなど。 -->