### PR TITLE
add find/get robotics task APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2261,6 +2261,85 @@ results = client.import_lerobot(
 
 > **Note:** Only LeRobot dataset v3 is supported. v2 datasets need to be converted to v3 before importing.
 
+#### Find Task
+
+Find a single task.
+
+```python
+task = client.find_robotics_task(task_id="YOUR_TASK_ID")
+```
+
+Find a single task by name.
+
+```python
+tasks = client.find_robotics_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+```
+
+#### Get Tasks
+
+Get tasks. (Up to 100 tasks)
+
+```python
+tasks = client.get_robotics_task(project="YOUR_PROJECT_SLUG")
+```
+
+- Filter and Get tasks. (Up to 100 tasks)
+
+```python
+tasks = client.get_robotics_task(
+    project="YOUR_PROJECT_SLUG",
+    status="approved", # status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined'
+    tags=["tag1", "tag2"] # up to 10 tags
+)
+```
+
+#### Response
+
+Example of a single robotics task object
+
+```python
+{
+    "id": "YOUR_TASK_ID",
+    "name": "episode_000000",
+    "status": "registered",
+    "externalStatus": "registered",
+    "contents": [
+        {
+            "name": "images_camera_01.mp4",
+            "url": "YOUR_CONTENT_URL",
+            "width": 640,
+            "height": 480
+        }
+    ],
+    "annotations": [
+        {
+            "id": "YOUR_ANNOTATION_ID",
+            "type": "sub_task",
+            "title": "grab",
+            "value": "grab",
+            "color": "#44AD8E",
+            "attributes": [],
+            "points": [13, 18],
+            "rotation": 0,
+            "keypoints": [],
+            "confidenceScore": -1
+        }
+    ],
+    "relations": [],
+    "tags": [],
+    "assignee": None,
+    "reviewer": None,
+    "approver": None,
+    "externalAssignee": None,
+    "externalReviewer": None,
+    "externalApprover": None,
+    "roboticsOperator": None,
+    "priority": 0,
+    "createdAt": "2021-02-22T11:25:27.158Z",
+    "updatedAt": "2021-02-22T11:25:27.158Z"
+}
+```
+
 ### Common
 
 APIs for update and delete and count are same over all tasks.

--- a/README.md
+++ b/README.md
@@ -2272,7 +2272,7 @@ task = client.find_robotics_task(task_id="YOUR_TASK_ID")
 Find a single task by name.
 
 ```python
-tasks = client.find_robotics_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+task = client.find_robotics_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
 ```
 
 #### Get Tasks
@@ -2280,16 +2280,17 @@ tasks = client.find_robotics_task_by_name(project="YOUR_PROJECT_SLUG", task_name
 Get tasks. (Up to 100 tasks)
 
 ```python
-tasks = client.get_robotics_task(project="YOUR_PROJECT_SLUG")
+tasks = client.get_robotics_tasks(project="YOUR_PROJECT_SLUG")
 ```
 
 - Filter and Get tasks. (Up to 100 tasks)
 
 ```python
-tasks = client.get_robotics_task(
+tasks = client.get_robotics_tasks(
     project="YOUR_PROJECT_SLUG",
-    status="approved", # status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined'
-    tags=["tag1", "tag2"] # up to 10 tags
+    status="approved",
+    # status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back', 'approved', 'declined'
+    tags=["tag1", "tag2"]  # up to 10 tags
 )
 ```
 

--- a/examples/find_robotics_task.py
+++ b/examples/find_robotics_task.py
@@ -1,0 +1,8 @@
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+task = client.find_robotics_task(task_id="YOUR_TASK_ID")
+pprint(task)

--- a/examples/get_robotics_task.py
+++ b/examples/get_robotics_task.py
@@ -1,0 +1,8 @@
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+tasks = client.get_robotics_task(project="YOUR_PROJECT_SLUG")
+pprint(tasks)

--- a/examples/get_robotics_task.py
+++ b/examples/get_robotics_task.py
@@ -4,5 +4,5 @@ import fastlabel
 
 client = fastlabel.Client()
 
-tasks = client.get_robotics_task(project="YOUR_PROJECT_SLUG")
+tasks = client.get_robotics_tasks(project="YOUR_PROJECT_SLUG")
 pprint(tasks)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2125,6 +2125,68 @@ class Client:
 
         return self.api.post_request(endpoint, payload=payload)
 
+    def find_robotics_task(self, task_id: str) -> dict:
+        """
+        Find a single robotics task.
+        """
+        endpoint = "tasks/robotics/" + task_id
+        return self.api.get_request(endpoint)
+
+    def find_robotics_task_by_name(self, project: str, task_name: str) -> dict:
+        """
+        Find a single robotics task by name.
+
+        project is slug of your project (Required).
+        task_name is a task name (Required).
+        """
+        tasks = self.get_robotics_task(project=project, task_name=task_name)
+        if not tasks:
+            return None
+        return tasks[0]
+
+    def get_robotics_task(
+        self,
+        project: str,
+        status: Optional[str] = None,
+        external_status: Optional[str] = None,
+        tags: Optional[list[str]] = None,
+        task_name: Optional[str] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ):
+        """
+        Returns a list of robotics tasks.
+        Returns up to 100 at a time, to get more,
+        set offset as the starting position to fetch.
+
+        project is slug of your project (Required).
+        status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined'. (Optional)
+        external_status can be 'registered', 'completed', 'skipped',
+        'reviewed', 'sent_back', 'approved', 'declined',
+        'customer_declined' (Optional).
+        tags is a list of tag (Optional).
+        task_name is a task name (Optional).
+        offset is the starting position number to fetch (Optional).
+        limit is the max number to fetch (Optional).
+        """
+        if limit > 100:
+            raise FastLabelInvalidException(
+                "Limit must be less than or equal to 100.", 422
+            )
+        endpoint = "tasks/robotics"
+        params = {"project": project, "offset": offset, "limit": limit}
+        if status:
+            params["status"] = status
+        if external_status:
+            params["externalStatus"] = external_status
+        if tags:
+            params["tags"] = tags
+        if task_name:
+            params["taskName"] = task_name
+
+        return self.api.get_request(endpoint, params=params)
+
     def import_lerobot(
         self,
         project: str,

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2132,19 +2132,21 @@ class Client:
         endpoint = "tasks/robotics/" + task_id
         return self.api.get_request(endpoint)
 
-    def find_robotics_task_by_name(self, project: str, task_name: str) -> dict:
+    def find_robotics_task_by_name(
+        self, project: str, task_name: str
+    ) -> Optional[dict]:
         """
         Find a single robotics task by name.
 
         project is slug of your project (Required).
         task_name is a task name (Required).
         """
-        tasks = self.get_robotics_task(project=project, task_name=task_name)
+        tasks = self.get_robotics_tasks(project=project, task_name=task_name)
         if not tasks:
             return None
         return tasks[0]
 
-    def get_robotics_task(
+    def get_robotics_tasks(
         self,
         project: str,
         status: Optional[str] = None,
@@ -2153,7 +2155,7 @@ class Client:
         task_name: Optional[str] = None,
         offset: int = 0,
         limit: int = 100,
-    ):
+    ) -> List[dict]:
         """
         Returns a list of robotics tasks.
         Returns up to 100 at a time, to get more,


### PR DESCRIPTION
## Summary
- `find_robotics_task`, `find_robotics_task_by_name` を追加
- `get_robotics_task` に docstring を追加
- README に Find Task / Get Tasks / Response セクションを追加
- examples に `find_robotics_task.py`, `get_robotics_task.py` を追加


## Test plan
- [x] `find_robotics_task` で task_id 指定でタスクを取得できること

<img width="1039" height="234" alt="スクリーンショット 2026-03-26 7 07 48" src="https://github.com/user-attachments/assets/0ba5d2d5-1435-4ca3-bddf-a10388232c08" />


- [x] `find_robotics_task_by_name` でプロジェクトとタスク名指定でタスクを取得できること

<img width="993" height="392" alt="スクリーンショット 2026-03-26 7 08 02" src="https://github.com/user-attachments/assets/7735ff6e-6ba0-40fb-a3e6-01faac8dbe1e" />


- [x] `get_robotics_task` でフィルタ付きタスク一覧を取得できること

<img width="1107" height="473" alt="スクリーンショット 2026-03-26 7 08 16" src="https://github.com/user-attachments/assets/092ef6ed-3268-4a47-918f-cc649cedfa91" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)