### PR TITLE
add update_robotics_task and operator param to create_robotics_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -2294,6 +2294,35 @@ tasks = client.get_robotics_tasks(
 )
 ```
 
+#### Update Tasks
+
+Update a single robotics task.
+
+```python
+task_id = client.update_robotics_task(
+    task_id="YOUR_TASK_ID",
+    status="approved",
+    priority=10, # (optional) none: 0, low: 10, medium: 20, high: 30
+    assignee="USER_SLUG",
+    tags=["tag1", "tag2"],
+    operator="OPERATOR_NAME",  # (optional) name of operator
+    annotations=[
+        {
+            "type": "sub_task",
+            "value": "grab",
+            "start": 13,
+            "end": 18,
+        }
+    ],
+    metadatas=[  # (optional) metadata key-value pairs
+        {
+            "key": "metadata_key",
+            "value": "metadata_value"
+        }
+    ]
+)
+```
+
 #### Response
 
 Example of a single robotics task object

--- a/examples/update_robotics_task.py
+++ b/examples/update_robotics_task.py
@@ -1,0 +1,29 @@
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+task_id = client.update_robotics_task(
+    task_id="YOUR_TASK_ID",
+    status="approved",
+    priority=10,  # none: 0, low: 10, medium: 20, high: 30
+    assignee="USER_SLUG",
+    tags=["tag1", "tag2"],
+    operator="OPERATOR_NAME",
+    annotations=[
+        {
+            "type": "sub_task",
+            "value": "grab",
+            "start": 13,
+            "end": 18,
+        }
+    ],
+    metadatas=[
+        {
+            "key": "metadata_key",
+            "value": "metadata_value",
+        }
+    ],
+)
+pprint(task_id)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2080,7 +2080,8 @@ class Client:
         status: Optional[str] = None,
         external_status: Optional[str] = None,
         priority: Optional[Priority] = None,
-        tags: Optional[list[str]] = None,
+        tags: Optional[List[str]] = None,
+        operator: Optional[str] = None,
         metadatas: Optional[list] = None,
         **kwargs,
     ) -> str:
@@ -2098,6 +2099,7 @@ class Client:
             medium = 20,
             high = 30,
         tags is a list of tag to be set in advance (Optional).
+        operator is a name of operator (Optional).
         metadatas is a list of metadata key-value pairs to be set in advance (Optional).
             e.g.) [{"key": "metadata_key", "value": "some_value"}]
         assignee is slug of assigned user (Optional).
@@ -2117,7 +2119,9 @@ class Client:
         if priority is not None:
             payload["priority"] = priority
         if tags:
-            payload["tags"] = tags or []
+            payload["tags"] = tags
+        if operator is not None:
+            payload["operator"] = operator
         if metadatas:
             payload["metadatas"] = metadatas
 
@@ -2188,6 +2192,65 @@ class Client:
             params["taskName"] = task_name
 
         return self.api.get_request(endpoint, params=params)
+
+    def update_robotics_task(
+        self,
+        task_id: str,
+        status: Optional[str] = None,
+        external_status: Optional[str] = None,
+        priority: Optional[Priority] = None,
+        tags: Optional[List[str]] = None,
+        operator: Optional[str] = None,
+        annotations: Optional[List[dict]] = None,
+        metadatas: Optional[list] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Update a single robotics task.
+
+        task_id is an id of the task (Required).
+        status can be 'registered', 'completed', 'skipped', 'reviewed', 'sent_back',
+        'approved', 'declined' (Optional).
+        external_status can be 'registered', 'completed', 'skipped', 'reviewed',
+        'sent_back', 'approved', 'declined',  'customer_declined'. (Optional)
+        priority is the priority of the task (default: none) (Optional).
+        Set one of the numbers corresponding to:
+            none = 0,
+            low = 10,
+            medium = 20,
+            high = 30,
+        tags is a list of tag to be set (Optional).
+        operator is a name of operator (Optional).
+        annotations is a list of annotation to be set (Optional).
+        metadatas is a list of metadata key-value pairs to be set (Optional).
+            e.g.) [{"key": "metadata_key", "value": "some_value"}]
+        assignee is slug of assigned user (Optional).
+        reviewer is slug of review user (Optional).
+        approver is slug of approve user (Optional).
+        external_assignee is slug of external assigned user (Optional).
+        external_reviewer is slug of external review user (Optional).
+        external_approver is slug of external approve user (Optional).
+        """
+        endpoint = "tasks/robotics/" + task_id
+        payload = {}
+        if status:
+            payload["status"] = status
+        if external_status:
+            payload["externalStatus"] = external_status
+        if priority is not None:
+            payload["priority"] = priority
+        if tags:
+            payload["tags"] = tags
+        if operator is not None:
+            payload["operator"] = operator
+        if annotations:
+            payload["annotations"] = delete_extra_annotations_parameter(annotations)
+        if metadatas:
+            payload["metadatas"] = metadatas
+
+        self.__fill_assign_users(payload, **kwargs)
+
+        return self.api.put_request(endpoint, payload=payload)
 
     def import_lerobot(
         self,


### PR DESCRIPTION
## Summary
-`update_robotics_task` メソッドの追加
- `operator` を `create_robotics_task` に追加

## test
- [x] update メソッドで、問題なくアノテーションの追加、オペレーターの追加ができることを確認

<img width="923" height="191" alt="スクリーンショット 2026-04-08 13 41 56" src="https://github.com/user-attachments/assets/ecb5f0fa-1c97-4384-8286-a7f2eeb9dcb2" />

- [x] create メソッドで、オペレーターを設定できる

<img width="808" height="137" alt="スクリーンショット 2026-04-08 13 44 37" src="https://github.com/user-attachments/assets/07ca3982-8fa8-4f59-b556-2dac6a8cf1a5" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)