### PR TITLE
chore: Pillow/numpy/robotics extras を bump し Python 3.13/3.14 を CI に追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        numpy-version: ["1.26.*", "2.*"]
+        exclude:
+          - python-version: "3.13"
+            numpy-version: "1.26.*"
+          - python-version: "3.14"
+            numpy-version: "1.26.*"
 
     steps:
       - name: Checkout
@@ -56,7 +62,8 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install -e ".[dev]"
+          pip install -e ".[dev,robotics]"
+          pip install "numpy==${{ matrix.numpy-version }}"
 
       - name: Run pytest
         run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-robotics = ["pandas>=2.0.0", "pyarrow>=14.0.0"]
+robotics = ["pandas>=2.2.2", "pyarrow>=18.0.0"]
 dev = ["pytest>=7.0.0"]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "The official Python SDK for FastLabel API, the Data Platform for 
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [
-    { name = "eisuke-ueta", email = "eisuke.ueta@fastlabel.ai" }
+    { name = "fastlabel", email = "dev@fastlabel.ai" }
 ]
 dependencies = [
   "requests>=2.4.2,<3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "fastlabel"
 description = "The official Python SDK for FastLabel API, the Data Platform for AI"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     { name = "eisuke-ueta", email = "eisuke.ueta@fastlabel.ai" }
 ]
 dependencies = [
   "requests>=2.4.2,<3.0",
-  "numpy>=1.26.0,<2.0.0",
+  "numpy>=1.26.0,<3.0.0",
   "geojson>=2.0.0,<4.0",
   "xmltodict==0.12.0",
   "Pillow>=11.0.0,<13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "numpy>=1.26.0,<2.0.0",
   "geojson>=2.0.0,<4.0",
   "xmltodict==0.12.0",
-  "Pillow>=10.0.0,<11.0.0",
+  "Pillow>=11.0.0,<13.0.0",
   "opencv-python>=4.10.0,<5.0.0"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests>=2.4.2,<3.0
 numpy>=1.26.0,<2.0.0
 geojson>=2.0.0,<4.0
 xmltodict==0.12.0
-Pillow>=10.0.0,<11.0.0
+Pillow>=11.0.0,<13.0.0
 opencv-python>=4.10.0,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.4.2,<3.0
-numpy>=1.26.0,<2.0.0
+numpy>=1.26.0,<3.0.0
 geojson>=2.0.0,<4.0
 xmltodict==0.12.0
 Pillow>=11.0.0,<13.0.0

--- a/tests/test_lerobot_v3_parquet.py
+++ b/tests/test_lerobot_v3_parquet.py
@@ -1,0 +1,117 @@
+"""Tests for v3 pandas/pyarrow code paths.
+
+Covers _build_episode_map, get_episode_indices, _convert_episode_frames, and
+check_dependencies so that pandas/pyarrow major-version bumps surface
+breakage in CI.
+"""
+import pytest
+
+pd = pytest.importorskip("pandas")
+pa = pytest.importorskip("pyarrow")
+
+from fastlabel.lerobot import common, v3  # noqa: E402
+
+
+def _write_parquet(path, rows):
+    df = pd.DataFrame(rows)
+    df.to_parquet(path)
+
+
+@pytest.fixture
+def v3_dataset(tmp_path):
+    """Create a minimal v3 layout with two chunks and two episodes per file."""
+    data_dir = tmp_path / "data"
+    chunk0 = data_dir / "chunk-000"
+    chunk0.mkdir(parents=True)
+
+    rows = []
+    for ep in (0, 1):
+        for f in range(3):
+            rows.append(
+                {
+                    "episode_index": ep,
+                    "frame_index": f,
+                    "timestamp": float(f) * 0.1,
+                    "observation.state": [0.1 * f, 0.2 * f],
+                    "action": [1.0, 2.0],
+                }
+            )
+    _write_parquet(chunk0 / "file-000.parquet", rows)
+
+    chunk1 = data_dir / "chunk-001"
+    chunk1.mkdir(parents=True)
+    rows = [
+        {
+            "episode_index": 2,
+            "frame_index": f,
+            "timestamp": float(f) * 0.1,
+            "observation.state": [0.0, 0.0],
+            "action": [0.0, 0.0],
+        }
+        for f in range(2)
+    ]
+    _write_parquet(chunk1 / "file-000.parquet", rows)
+
+    return tmp_path
+
+
+class TestBuildEpisodeMap:
+    def test_returns_offsets_per_episode(self, v3_dataset):
+        result = v3._build_episode_map(v3_dataset)
+
+        assert set(result.keys()) == {0, 1, 2}
+        assert result[0] == {
+            "chunk": "chunk-000",
+            "file_stem": "file-000",
+            "frame_offset": 0,
+            "length": 3,
+        }
+        assert result[1] == {
+            "chunk": "chunk-000",
+            "file_stem": "file-000",
+            "frame_offset": 3,
+            "length": 3,
+        }
+        assert result[2] == {
+            "chunk": "chunk-001",
+            "file_stem": "file-000",
+            "frame_offset": 0,
+            "length": 2,
+        }
+
+    def test_get_episode_indices_sorted(self, v3_dataset):
+        assert v3.get_episode_indices(v3_dataset) == [0, 1, 2]
+
+
+class TestConvertEpisodeFrames:
+    def test_extracts_frame_dicts(self, v3_dataset):
+        frames = v3._convert_episode_frames(
+            v3_dataset, episode_index=1, chunk="chunk-000", file_stem="file-000"
+        )
+
+        assert len(frames) == 3
+        for i, frame in enumerate(frames):
+            assert frame["frame_index"] == i
+            assert frame["timestamp"] == pytest.approx(i * 0.1)
+            assert frame["action"] == [1.0, 2.0]
+            assert isinstance(frame["observation.state"], list)
+
+    def test_missing_required_columns_returns_empty(self, tmp_path):
+        chunk = tmp_path / "data" / "chunk-000"
+        chunk.mkdir(parents=True)
+        _write_parquet(
+            chunk / "file-000.parquet",
+            [{"episode_index": 0, "frame_index": 0}],
+        )
+
+        assert (
+            v3._convert_episode_frames(
+                tmp_path, episode_index=0, chunk="chunk-000", file_stem="file-000"
+            )
+            == []
+        )
+
+
+class TestCheckDependencies:
+    def test_returns_when_available(self):
+        common.check_dependencies()

--- a/tests/test_lerobot_v3_parquet.py
+++ b/tests/test_lerobot_v3_parquet.py
@@ -24,18 +24,17 @@ def v3_dataset(tmp_path):
     chunk0 = data_dir / "chunk-000"
     chunk0.mkdir(parents=True)
 
-    rows = []
-    for ep in (0, 1):
-        for f in range(3):
-            rows.append(
-                {
-                    "episode_index": ep,
-                    "frame_index": f,
-                    "timestamp": float(f) * 0.1,
-                    "observation.state": [0.1 * f, 0.2 * f],
-                    "action": [1.0, 2.0],
-                }
-            )
+    rows = [
+        {
+            "episode_index": ep,
+            "frame_index": f,
+            "timestamp": float(f) * 0.1,
+            "observation.state": [0.1 * f, 0.2 * f],
+            "action": [1.0, 2.0],
+        }
+        for ep in (0, 1)
+        for f in range(3)
+    ]
     _write_parquet(chunk0 / "file-000.parquet", rows)
 
     chunk1 = data_dir / "chunk-001"

--- a/tests/test_pillow_exports.py
+++ b/tests/test_pillow_exports.py
@@ -1,0 +1,167 @@
+"""Smoke tests for Pillow-using code paths.
+
+These exercise the Image.open/new/fromarray/composite, convert, putpalette,
+save, ImageDraw, and ImageColor calls inside fastlabel/__init__.py so that
+Pillow major-version bumps surface API breakage in CI.
+"""
+import os
+
+import numpy as np
+import pytest
+from PIL import Image
+
+import fastlabel
+from fastlabel import const
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("FASTLABEL_ACCESS_TOKEN", "dummy-token")
+    return fastlabel.Client()
+
+
+def _bbox_task(name="task1.png", w=64, h=48):
+    return {
+        "name": name,
+        "width": w,
+        "height": h,
+        "annotations": [
+            {
+                "type": "bbox",
+                "value": "cat",
+                "color": "#ff0000",
+                "points": [10, 10, 40, 30],
+            }
+        ],
+    }
+
+
+def _polygon_task(name="task2.png", w=64, h=48):
+    return {
+        "name": name,
+        "width": w,
+        "height": h,
+        "annotations": [
+            {
+                "type": "polygon",
+                "value": "dog",
+                "color": "#00ff00",
+                "points": [5, 5, 50, 5, 50, 40, 5, 40],
+            }
+        ],
+    }
+
+
+def _segmentation_task(name="task3.png", w=64, h=48):
+    return {
+        "name": name,
+        "width": w,
+        "height": h,
+        "annotations": [
+            {
+                "type": "segmentation",
+                "value": "bird",
+                "color": "#0000ff",
+                "points": [[[5, 5, 50, 5, 50, 40, 5, 40]]],
+            }
+        ],
+    }
+
+
+class TestExportIndexColorImage:
+    """Covers Image.new, Image.fromarray, convert('P'), putpalette, save."""
+
+    def _call(self, client, task, output_dir, **kwargs):
+        client._Client__export_index_color_image(
+            task=task,
+            output_dir=str(output_dir),
+            pallete=const.COLOR_PALETTE,
+            **kwargs,
+        )
+
+    def _assert_indexed_png(self, path):
+        assert os.path.exists(path)
+        with Image.open(path) as img:
+            assert img.mode == "P"
+            assert img.getpalette() is not None
+            assert img.size == (64, 48)
+
+    def test_bbox_instance(self, client, tmp_path):
+        task = _bbox_task()
+        self._call(client, task, tmp_path, is_instance_segmentation=True)
+        self._assert_indexed_png(tmp_path / "task1.png")
+
+    def test_polygon_semantic(self, client, tmp_path):
+        task = _polygon_task()
+        self._call(
+            client,
+            task,
+            tmp_path,
+            is_instance_segmentation=False,
+            classes=["dog"],
+        )
+        self._assert_indexed_png(tmp_path / "task2.png")
+
+    def test_segmentation_instance(self, client, tmp_path):
+        task = _segmentation_task()
+        self._call(client, task, tmp_path, is_instance_segmentation=True)
+        self._assert_indexed_png(tmp_path / "task3.png")
+
+
+class TestCreateImageWithAnnotation:
+    """Covers Image.open, ImageDraw.Draw, ImageColor.getcolor, Image.composite."""
+
+    def _make_source_image(self, path, w=64, h=48):
+        arr = np.full((h, w, 3), 200, dtype=np.uint8)
+        Image.fromarray(arr).save(path)
+
+    def _call(self, client, img_path, task, output_dir):
+        client._Client__create_image_with_annotation(
+            [str(img_path), task, str(output_dir)]
+        )
+
+    def test_bbox(self, client, tmp_path):
+        src = tmp_path / "src.png"
+        self._make_source_image(src)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        task = _bbox_task(name="src.png")
+        self._call(client, src, task, out_dir)
+        result = out_dir / "src.png"
+        assert result.exists()
+        with Image.open(result) as img:
+            assert img.size == (64, 48)
+
+    def test_polygon(self, client, tmp_path):
+        src = tmp_path / "p.png"
+        self._make_source_image(src)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        task = _polygon_task(name="p.png")
+        self._call(client, src, task, out_dir)
+        assert (out_dir / "p.png").exists()
+
+    def test_segmentation_triggers_composite(self, client, tmp_path):
+        src = tmp_path / "s.png"
+        self._make_source_image(src)
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        task = _segmentation_task(name="s.png")
+        self._call(client, src, task, out_dir)
+        result = out_dir / "s.png"
+        assert result.exists()
+        with Image.open(result) as img:
+            assert img.mode in ("RGB", "RGBA")
+
+    def test_segmentation_jpeg_converts_rgb(self, client, tmp_path):
+        src = tmp_path / "s.jpg"
+        arr = np.full((48, 64, 3), 200, dtype=np.uint8)
+        Image.fromarray(arr).save(src, format="JPEG")
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        task = _segmentation_task(name="s.jpg")
+        self._call(client, src, task, out_dir)
+        result = out_dir / "s.jpg"
+        assert result.exists()
+        with Image.open(result) as img:
+            assert img.mode == "RGB"


### PR DESCRIPTION
## 概要
#273 の Phase B + Phase C を 1 PR にまとめて対応。

- **Pillow**: `>=10.0.0,<11.0.0` → `>=11.0.0,<13.0.0`(Python 3.13/3.14 wheel 対応)
- **numpy**: `>=1.26.0,<2.0.0` → `>=1.26.0,<3.0.0`(1.x / 2.x 両対応)
- **requires-python**: `>=3.8` → `>=3.10`(Python 3.8/3.9 サポート終了)
- **robotics extras**: `pandas>=2.0.0` → `>=2.2.2`、`pyarrow>=14.0.0` → `>=18.0.0`(numpy 2 / Python 3.13+ 対応)
- **release.yml**: Python `3.8` → `3.10`
- **test.yml**: matrix を `Python 3.10–3.14 × numpy 1.26 / 2.x` に拡張(3.13/3.14 + numpy 1.26 は wheel 未提供のため exclude)。robotics extras も install して pandas/pyarrow も実行。
- Pillow / pandas / pyarrow の利用箇所をカバーする smoke テストを追加し、今後のメジャー bump で API 破壊が CI で検出されるように。

## 変更点

### `pyproject.toml` / `requirements.txt`
| 項目 | 変更前 | 変更後 |
|---|---|---|
| `requires-python` | `>=3.8` | `>=3.10` |
| `numpy` | `>=1.26.0,<2.0.0` | `>=1.26.0,<3.0.0` |
| `Pillow` | `>=10.0.0,<11.0.0` | `>=11.0.0,<13.0.0` |
| `pandas` (robotics) | `>=2.0.0` | `>=2.2.2` |
| `pyarrow` (robotics) | `>=14.0.0` | `>=18.0.0` |

### `.github/workflows/test.yml`
```yaml
matrix:
  python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
  numpy-version: ["1.26.*", "2.*"]
  exclude:
    - python-version: "3.13"
      numpy-version: "1.26.*"
    - python-version: "3.14"
      numpy-version: "1.26.*"
```

## コードへの影響
- numpy 2.0 で削除された API(`np.float_`, `np.NaN`, `np.product` 等)は未使用
- 使用 API(`np.array`, `np.vstack`, `np.uint8`, `np.int32`, `Image.open/new/fromarray/composite`, `pd.read_parquet`, `iterrows` 等)は対象範囲で安定
- コード本体の修正は不要

## テスト計画
- [x] Pillow 11.3.0 / numpy 2.0.2 / pandas 2.3.3 / pyarrow 21.0.0 で `pytest` 全 40 件パス
- [x] 旧下限(Pillow 10.4.0 / numpy 1.26 / pandas 2.0.0 / pyarrow 14.0.0)でも新テスト通過を確認
- [x] CI matrix (3.10-3.14 × numpy 1.26/2.x) が green

🤖 Generated with [Claude Code](https://claude.com/claude-code)