### PR TITLE
feat: Robotics mcap インポートパイプライン追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2234,7 +2234,7 @@ history = client.import_robotics_contents_file(
 
 Import an mcap zip file into an existing robotics task.
 
-This method starts an import pipeline, uploads the zip file via a signed URL, and triggers the batch import.
+This method uploads the zip file and starts the import. The import runs **asynchronously** on the server, so the call returns as soon as the import is accepted — it does **not** wait for the import to finish.
 
 ```python
 result = client.import_robotics_mcap(
@@ -2243,6 +2243,8 @@ result = client.import_robotics_mcap(
     file_path="ZIP_FILE_PATH",  # Supported extension is .zip
 )
 ```
+
+There is no API to poll the import progress. Check the import status (and any errors) on the import history screen (`/imports`) in the FastLabel application.
 
 #### Import LeRobot Dataset
 

--- a/README.md
+++ b/README.md
@@ -2230,6 +2230,20 @@ history = client.import_robotics_contents_file(
 )
 ```
 
+#### Import mcap
+
+Import an mcap zip file into an existing robotics task.
+
+This method starts an import pipeline, uploads the zip file via a signed URL, and triggers the batch import.
+
+```python
+result = client.import_robotics_mcap(
+    project="YOUR_PROJECT_SLUG",
+    task_id="YOUR_TASK_ID",
+    file_path="ZIP_FILE_PATH",  # Supported extension is .zip
+)
+```
+
 #### Import LeRobot Dataset
 
 Import a [LeRobot](https://github.com/huggingface/lerobot) dataset (v3) into a FastLabel robotics project.

--- a/examples/import_robotics_mcap.py
+++ b/examples/import_robotics_mcap.py
@@ -1,0 +1,19 @@
+"""
+Import an mcap zip file into an existing FastLabel robotics task.
+
+This starts an import pipeline, uploads the zip via a signed URL,
+and triggers the batch import.
+"""
+
+from pprint import pprint
+
+import fastlabel
+
+client = fastlabel.Client()
+
+result = client.import_robotics_mcap(
+    project="YOUR_PROJECT_SLUG",
+    task_id="YOUR_TASK_ID",
+    file_path="ZIP_FILE_PATH",  # Supported extension is .zip
+)
+pprint(result)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2451,6 +2451,54 @@ class Client:
 
         return self.api.post_request(endpoint, payload=payload)
 
+    def import_robotics_mcap(self, project: str, task_id: str, file_path: str) -> dict:
+        """
+        Import robotics mcap zip file.
+        project is slug of your project (Required).
+        task_id is a id of the robotics task to import contents (Required).
+        file_path is a path to data. Supported extensions are zip (Required).
+        """
+        if not file_path.endswith(".zip"):
+            raise FastLabelInvalidException(
+                "Supported extensions are zip (Required).", 422
+            )
+        history_id = self._start_pipeline(project=project, task_id=task_id)
+        self._upload_zip_with_signed_url(
+            history_id=history_id,
+            file_path=file_path,
+        )
+        return self._trigger_batch_import(history_id=history_id)
+
+    def _start_pipeline(
+        self,
+        project: str,
+        task_id: str,
+    ) -> str:
+        history: dict = self.api.post_request(
+            "data-lake/import-pipeline/start",
+            payload={
+                "project": project,
+                "taskId": task_id,
+            },
+        )
+        logger.info(f"Started data lake pipeline with history ID: {history['id']}")
+        return history["id"]
+
+    def _upload_zip_with_signed_url(self, history_id: str, file_path: str) -> None:
+        url = self.api.get_request(
+            "data-lake/import-pipeline/signed-url", params={"historyId": history_id}
+        )
+        res = self.api.upload_zipfile(url=url, file_path=file_path)
+        res.raise_for_status()
+
+    def _trigger_batch_import(self, history_id: str) -> dict:
+        return self.api.post_request(
+            "data-lake/import-pipeline/run",
+            payload={
+                "historyId": history_id,
+            },
+        )
+
     # Task Update
 
     def update_task(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2475,7 +2475,7 @@ class Client:
         task_id: str,
     ) -> str:
         history: dict = self.api.post_request(
-            "data-lake/import-pipeline/start",
+            "data-lake/robotics/import-pipeline/start",
             payload={
                 "project": project,
                 "taskId": task_id,
@@ -2485,15 +2485,16 @@ class Client:
         return history["id"]
 
     def _upload_zip_with_signed_url(self, history_id: str, file_path: str) -> None:
-        url = self.api.get_request(
-            "data-lake/import-pipeline/signed-url", params={"historyId": history_id}
+        signed_url_data = self.api.get_request(
+            "data-lake/robotics/import-pipeline/signed-url",
+            params={"historyId": history_id},
         )
-        res = self.api.upload_zipfile(url=url, file_path=file_path)
+        res = self.api.upload_zipfile(url=signed_url_data["url"], file_path=file_path)
         res.raise_for_status()
 
     def _trigger_batch_import(self, history_id: str) -> dict:
         return self.api.post_request(
-            "data-lake/import-pipeline/run",
+            "data-lake/robotics/import-pipeline/run",
             payload={
                 "historyId": history_id,
             },

--- a/fastlabel/api.py
+++ b/fastlabel/api.py
@@ -19,7 +19,7 @@ class Api:
             raise ValueError("FASTLABEL_ACCESS_TOKEN is not configured.")
         self.access_token = "Bearer " + access_token
 
-    def get_request(self, endpoint: str, params=None) -> Union[dict, list, str]:
+    def get_request(self, endpoint: str, params=None) -> Union[dict, list]:
         """Makes a get request to an endpoint.
         If an error occurs, assumes that endpoint returns JSON as:
             { 'statusCode': XXX,

--- a/fastlabel/api.py
+++ b/fastlabel/api.py
@@ -19,7 +19,7 @@ class Api:
             raise ValueError("FASTLABEL_ACCESS_TOKEN is not configured.")
         self.access_token = "Bearer " + access_token
 
-    def get_request(self, endpoint: str, params=None) -> Union[dict, list]:
+    def get_request(self, endpoint: str, params=None) -> Union[dict, list, str]:
         """Makes a get request to an endpoint.
         If an error occurs, assumes that endpoint returns JSON as:
             { 'statusCode': XXX,


### PR DESCRIPTION
## 概要

Robotics 向けの mcap zip ファイルインポート機能を追加します。

## 変更内容

- `import_robotics_mcap(project, task_id, file_path)` を `Client` に追加
  - signed URL を取得して zip をアップロードし、バッチインポートをトリガーする3ステップのパイプライン
  - `.zip` 拡張子以外は `FastLabelInvalidException` を送出
- 内部メソッド `_start_pipeline` / `_upload_zip_with_signed_url` / `_trigger_batch_import` を追加
- import-pipeline 系エンドポイントを `data-lake/robotics/` 配下に変更
- signed-url レスポンスを dict 形式（`url` キー）に対応
- `Api.get_request` の戻り値型に `str` を追加

## テスト

- [ ] 未実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)