### PR TITLE
空の配列でアノテーションを更新できるように修正

### DIFF
--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -2243,7 +2243,7 @@ class Client:
             payload["tags"] = tags
         if operator is not None:
             payload["operator"] = operator
-        if annotations:
+        if annotations is not None:
             payload["annotations"] = delete_extra_annotations_parameter(annotations)
         if metadatas:
             payload["metadatas"] = metadatas


### PR DESCRIPTION
`annotations=[]` の時にif分岐でリクエストに含まれない挙動を修正しました。
他のアノテーションでも起きうる状態であることは確認しましたが、影響範囲を考えて robotics のみの修正です。