### PR TITLE
fix(release): タグからバージョンを確実に解決し、deprecated アクションを更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0 # setuptools_scm needs full history and tags to resolve the version
+          fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
         with:
           python-version: "3.10"
 
@@ -32,6 +35,6 @@ jobs:
 
       - name: Publish a Python distribution to PyPI
         if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pypi_update_guide.md
+++ b/pypi_update_guide.md
@@ -41,6 +41,13 @@ _Creating and deploying a new package version is easy_
      - input [version](#version) (ex: `1.12.0`)
      - Click `Create new tag: x.x.x`
 
+     > **Note:** The tag name becomes the published package version. It is resolved
+     > automatically from the Git tag by `setuptools_scm` (there is no version string
+     > to edit in the source), so enter the exact version, matching the existing tag
+     > format (e.g. `1.12.0`, no `v` prefix). Creating the tag together with the
+     > release here is fine — the workflow checks out the full history and tags, so
+     > the version always resolves correctly.
+
    - Target: main
 
    - Release title: `Release x.x.x` (ex: `Release 1.12.0`)
@@ -68,6 +75,13 @@ If the workflow fails, follow these steps:
 ---
 
 ### Version
+
+The package version is **derived automatically from the Git tag** by
+[`setuptools_scm`](https://github.com/pypa/setuptools-scm) — see `[tool.setuptools_scm]`
+and `dynamic = ["version"]` in `pyproject.toml`. There is no version string to edit in
+the source; the tag you create in Step 1 is what gets published to PyPI, so it must be a
+valid version. (If the tag cannot be resolved, the build falls back to a dev version like
+`0.1.dev1+g<sha>`, which PyPI rejects with a `400 Bad Request`.)
 
 We use [semantic versioning](https://packaging.python.org/guides/distributing-packages-using-setuptools/#semantic-versioning-preferred).  
 If you are adding a meaningful feature, bump the minor version.  


### PR DESCRIPTION
## 概要

リリース時の `build-n-publish` ジョブが**実行ごとに成功したり失敗したりする**問題を修正します。失敗時は `Publish a Python distribution to PyPI` ステップで `400 Bad Request` が発生していました。

あわせて、sunset / deprecated になっている GitHub Actions を更新し、SHA 固定にします。

## 根本原因

このパッケージは `setuptools_scm` による**動的バージョニング**を採用しています。

- `pyproject.toml` → `dynamic = ["version"]` / `[tool.setuptools_scm]`
- バージョンはソース内に書かれておらず、`setuptools_scm` が **Git タグ**（`git describe` 相当）から算出します。

一方、`release.yml` の checkout は `actions/checkout@v2` を**デフォルト設定**で使っていました。デフォルトは `fetch-depth: 1` の**浅い（shallow）チェックアウト**で、単一コミットしか取得せず**タグやフル履歴を確実には取得しません**。

その結果、ビルド時に対象タグが手元に存在するかどうかが**実行タイミングに依存**し、以下のように分岐していました。

| 状態 | バージョン解決 | 結果 |
|------|----------------|------|
| タグが取得できている | `0.21.0` | ✅ success |
| タグが取りこぼされる | フォールバック `0.1.dev1+g<sha>` | ❌ failure |

### ログが示していた事実

失敗時の成果物名は `fastlabel-0.1.dev1+g6e97b6cd0` でした。この `g6e97b6cd0` は、**タグ `0.21.0` が付いているコミット `6e97b6c`（main の HEAD のマージコミット）そのもの**です。

- ローカル確認: `git rev-list -n 1 0.21.0` → `6e97b6cd0...` / `git describe --tags 6e97b6c` → `0.21.0`

つまり**正しいコミットはチェックアウトできていた**が、そのチェックアウトに**タグが含まれていなかった**ため、`setuptools_scm` がフォールバック値 `0.1.dev1+g<sha>` を採用していた、ということです。

### なぜ「タグとリリースを分けて作成すると成功する」のか

GitHub UI で「新規タグ作成」と「Publish release」を同時に行うと、`release: published` イベント発火 → checkout 実行 までの間にタグの伝搬が間に合わず、浅い checkout がコミットだけ取得してタグを取りこぼすレースが起きます。タグを**先に作成**してからリリースを公開すると、checkout 時点でタグが確実に存在するため毎回 `0.21.0` に解決される、という挙動でした（操作者の観察と一致）。

### PyPI の `400 Bad Request` について

これは上記の**二次的な症状**です。`0.1.dev1+g6e97b6cd0` の `+g6e97b6cd0` は PEP 440 の**ローカルバージョンラベル**で、**PyPI はローカルラベル付きのアップロードを拒否**します → `400 Bad Request`。間違ったバージョンが生成された結果、アップロードが弾かれていました。

## 修正内容

### `.github/workflows/release.yml`

- **checkout に `fetch-depth: 0` / `fetch-tags: true` を追加**（本質的修正）
  全履歴＋タグを取得し、トリガーのタイミングに関わらず `setuptools_scm` が常にタグからバージョンを解決できるようにします。これにより**タグとリリースを同時に作成しても**確実に動作し、「分けて作成する」回避策が不要になります。
- deprecated アクションを更新し SHA 固定
  - `actions/checkout` `@v2` → `@692973e…` (v4)
  - `actions/setup-python` `@v2` → `@39cd149…` (v5)
  - `pypa/gh-action-pypi-publish` `@master`(sunset) → `@cef2210…` (v1.14.0)
  - ※ checkout / setup-python は `test.yml` と同一 SHA に統一。pypi-publish は `password`（`PYPI_API_TOKEN`）ベースの認証を従来どおり継続。

### `pypi_update_guide.md`

- バージョンがタグから自動導出される仕組み・タグ名がそのまま公開バージョンになること・解決失敗時に `0.1.dev1+g<sha>` へフォールバックして PyPI に弾かれることを明記。手順（Step 1〜3）自体は変更なし。

## 動作確認方法

次回リリース時に `Check` ジョブのログで `dist` 内が `fastlabel-<正しいバージョン>` になっていることを確認してください（`0.1.dev1+...` にならない）。

## 補足（任意・今後の検討）

`pypa/gh-action-pypi-publish` v1.14.0 以降は **Trusted Publishing（OIDC, トークンレス）** を推奨しています。`password` を撤廃し `permissions: id-token: write` + PyPI 側の信頼設定に移行すると、シークレット管理が不要になります。本 PR では既存のトークン方式を維持しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)