### PR TITLE
Pythonサポートバージョンの記載を3.10に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ https://api.fastlabel.ai/docs
 pip install --upgrade fastlabel
 ```
 
-> Python version 3.8 or greater is required
+> Python version 3.10 or greater is required
 
 ## Usage
 


### PR DESCRIPTION
## 概要

README の Installation セクションに記載されている対応 Python バージョンが
`3.8 or greater` のままだったため、`3.10 or greater` に修正

## 背景

実際のコードベースでは既に Python 3.10+ 前提に移行済み
- `pyproject.toml`: `requires-python = ">=3.10"`
- `.github/workflows/release.yml`: `python-version: "3.10"`
- `.github/workflows/test.yml`: テスト対象は 3.10〜3.14

README の記載だけが追従できていなかったため、整合性を取る

## 変更内容

- `README.md`: `Python version 3.8 or greater is required` → `3.10 or greater`

## 影響範囲

ドキュメントのみ。コード・パッケージの挙動への影響はなし
