### PR TITLE
chore(ci): Node 24対応のためGitHub Actionsのバージョンを更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0 # setuptools_scm needs full history and tags to resolve the version
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           cache: pip
           python-version: "3.10.11"
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           cache: pip
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## 概要

build-n-publish ジョブで出ていた **Node.js 20 deprecation** の警告を解消するため、Node 24 対応の安定版へ GitHub Actions のバージョンを更新します。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout, actions/setup-python.

## 変更内容

SHA固定のまま、以下を更新しました（いずれも現行から +1 メジャーの安定版）。

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4.1.7 | **v5.0.1** |
| `actions/setup-python` | v5.1.1 | **v6.3.0** |

対象ファイル:
- `release.yml`（build-n-publish）
- `test.yml`（lint / test ※同一アクションを使用しており同じ警告対象のため合わせて更新）

## 今回見送ったもの

build-n-publish では他に以下の警告も出ていますが、PyPI側の設定および認証方式（APIトークン → Trusted Publishing）の変更を伴うため、別途対応します。

- Create a Trusted Publisher / Upgrade to Trusted Publishing
- attestations input ignored（Trusted Publishing 移行とセットで対応予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)