### PR TITLE
chore(deps): black を 26.5.1 に更新し開発ツールのバージョンを統一

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Python tools
         run: |
-          pip install black==26.5.1 flake8==5.0.4 isort==5.11.5
+          pip install black==26.5.1 flake8==7.3.0 isort==5.11.5
 
       - name: Run black
         run: black --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Python tools
         run: |
-          pip install black==22.10.0 flake8==5.0.4 isort==5.11.5
+          pip install black==26.5.1 flake8==5.0.4 isort==5.11.5
 
       - name: Run black
         run: black --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 26.5.1
     hooks:
       -   id: black
           files: '^.*\.py'

--- a/contributing/requirements.txt
+++ b/contributing/requirements.txt
@@ -1,6 +1,6 @@
 black==26.5.1
-flake8==5.0.4
-isort==5.10.1
+flake8==7.3.0
+isort==5.11.5
 pre-commit==2.20.0
 pytest==7.2.0
 pytest-dotenv==0.5.2

--- a/contributing/requirements.txt
+++ b/contributing/requirements.txt
@@ -1,4 +1,4 @@
-black==22.10.0
+black==26.5.1
 flake8==5.0.4
 isort==5.10.1
 pre-commit==2.20.0

--- a/fastlabel/utils/mask_image_util.py
+++ b/fastlabel/utils/mask_image_util.py
@@ -67,7 +67,10 @@ def __detect_segmentation_list(
         segmentation_list.append(segmentation)
 
         for separate_place_hierarchy_index in separate_place_hierarchy_indexes:
-            (segmentation, _,) = __detect_segmentation(
+            (
+                segmentation,
+                _,
+            ) = __detect_segmentation(
                 separate_place_hierarchy_index, hierarchy, contours
             )
             segmentation_list.append(segmentation)

--- a/tests/test_lerobot_v3_parquet.py
+++ b/tests/test_lerobot_v3_parquet.py
@@ -4,6 +4,7 @@ Covers _build_episode_map, get_episode_indices, _convert_episode_frames, and
 check_dependencies so that pandas/pyarrow major-version bumps surface
 breakage in CI.
 """
+
 import pytest
 
 pd = pytest.importorskip("pandas")

--- a/tests/test_pillow_exports.py
+++ b/tests/test_pillow_exports.py
@@ -4,6 +4,7 @@ These exercise the Image.open/new/fromarray/composite, convert, putpalette,
 save, ImageDraw, and ImageColor calls inside fastlabel/__init__.py so that
 Pillow major-version bumps surface API breakage in CI.
 """
+
 import os
 
 import numpy as np

--- a/tests/test_workspace_user.py
+++ b/tests/test_workspace_user.py
@@ -4,6 +4,7 @@ These verify that get/create/update/delete_workspace_user build the correct
 endpoint, query params and payload. The HTTP layer (client.api.*_request) is
 stubbed so no real request is made.
 """
+
 import pytest
 
 import fastlabel


### PR DESCRIPTION
## 概要

Dependabot アラート (black `<24.3.0` の ReDoS 脆弱性 [GHSA-fj7x-q9j7-g6q6](https://github.com/advisories/GHSA-fj7x-q9j7-g6q6) / security/dependabot/12) を解消するため black を更新。あわせて開発ツール (flake8/isort) のバージョンが3箇所でズレていたため統一しました。

## 背景

`black==22.10.0` などの開発ツールのバージョンが、以下の3箇所に重複してハードコードされていました。バージョンがズレるとローカルの pre-commit と CI の lint 結果が食い違うため、すべて揃える必要があります。

- `contributing/requirements.txt` … コントリビューターのローカル開発ツール
- `.github/workflows/test.yml` … CI の lint ジョブ
- `.pre-commit-config.yaml` … pre-commit フック

## 変更内容

3箇所すべてを以下のバージョンに統一しました（exact pin）。

| ツール | Before (各ファイルでバラバラ) | After (統一) |
|--------|------|------|
| black | 22.10.0 | **26.5.1** |
| flake8 | 5.0.4 / 5.0.4 / 7.3.0 | **7.3.0** |
| isort | 5.10.1 / 5.11.5 / 5.11.5 | **5.11.5** |

black の更新に伴い、2024+ stable style に追従して4ファイルを再フォーマットしています（機能変更なし）。

- `fastlabel/utils/mask_image_util.py` — magic trailing comma によるタプル展開
- `tests/test_lerobot_v3_parquet.py` / `test_pillow_exports.py` / `test_workspace_user.py` — module docstring 直後の空行追加

## 検証

CI と同じ Python 3.10 + 確定バージョンで lint trio がすべてパスすることを確認済み。

- `black --check .` → ✅ exit 0
- `flake8 .` → ✅ exit 0（flake8 7.3.0 でも追加のコード修正なし）
- `isort --check .` → ✅ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)