### PR TITLE
docs: README に未記載の Client メソッド2件を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -1948,7 +1948,7 @@ task = client.find_sequential_pcd_task(task_id="YOUR_TASK_ID")
 Find a single task by name.
 
 ```python
-tasks = client.find_sequential_pcd_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+task = client.find_sequential_pcd_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
 ```
 
 #### Get Tasks

--- a/README.md
+++ b/README.md
@@ -1948,7 +1948,7 @@ task = client.find_sequential_pcd_task(task_id="YOUR_TASK_ID")
 Find a single task by name.
 
 ```python
-task = client.find_sequential_pcd_task(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
+tasks = client.find_sequential_pcd_task_by_name(project="YOUR_PROJECT_SLUG", task_name="YOUR_TASK_NAME")
 ```
 
 #### Get Tasks
@@ -2941,6 +2941,14 @@ Get projects. (Up to 1000 projects)
 
 ```python
 projects = client.get_projects()
+```
+
+### Get Projects Id and Slug map
+
+Get a map of project ids and slugs. (Up to 1000 projects)
+
+```python
+id_slug_map = client.get_project_id_slug_map()
 ```
 
 ### Response


### PR DESCRIPTION
## 概要

`class Client`（`fastlabel/__init__.py`）と `README.md` を突き合わせた結果、README に記載が漏れていた public メソッド2件を追記しました。

## 変更内容

| メソッド | 対応 |
|---|---|
| `find_sequential_pcd_task_by_name` | 「Find a single task by name」の例が専用メソッドではなく `find_sequential_pcd_task(project=..., task_name=...)` を使っていたため、他フォーマット（例: `find_pcd_task_by_name`）と同じく専用メソッドを使う形に修正 |
| `get_project_id_slug_map` | Project セクションの「Get Projects」直後に「Get Projects Id and Slug map」を新規追加。類似の `get_task_id_name_map` の記載スタイルに準拠 |

いずれも README 既存のセクション構成・見出しレベル・コードブロックのスタイルに従っています。これで `Client` の public メソッドはすべて README でカバーされました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)