### PR TITLE
アノテーションクラスの領域数上限をSDKから指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -2842,6 +2842,15 @@ annotation_id = client.update_annotation(
     annotation_id="YOUR_ANNOTATION_ID", value="cat2", title="Cat2", color="#FF0000", attributes=attributes)
 ```
 
+Update the maximum number of regions of a segmentation annotation.
+
+`max_area_count` is left unchanged when omitted. Set `None` to allow any number of regions.
+
+```python
+annotation_id = client.update_annotation(
+    annotation_id="YOUR_ANNOTATION_ID", max_area_count=None)
+```
+
 Update a classification annotation.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -2665,6 +2665,17 @@ annotation_id = client.create_annotation(
     project="YOUR_PROJECT_SLUG", type="bbox", value="cat", title="Cat", color="#FF0000", attributes=attributes)
 ```
 
+Create a new segmentation annotation that allows disjoint regions.
+
+`max_area_count` is the maximum number of separate regions a single segmentation annotation may
+consist of. It only applies to segmentation classes and defaults to `1`, which disallows disjoint
+regions. Set `None` to allow any number of regions.
+
+```python
+annotation_id = client.create_annotation(
+    project="YOUR_PROJECT_SLUG", type="segmentation", value="cat", title="Cat", max_area_count=None)
+```
+
 Create a new classification annotation.
 
 ```python

--- a/README.md
+++ b/README.md
@@ -2668,8 +2668,8 @@ annotation_id = client.create_annotation(
 Create a new segmentation annotation that allows disjoint regions.
 
 `max_area_count` is the maximum number of separate regions a single segmentation annotation may
-consist of. It only applies to segmentation classes and defaults to `1`, which disallows disjoint
-regions. Set `None` to allow any number of regions.
+consist of, between 1 and 1000. It only applies to segmentation classes and defaults to `1`, which
+disallows disjoint regions. Set `None` to allow any number of regions.
 
 ```python
 annotation_id = client.create_annotation(
@@ -2844,7 +2844,8 @@ annotation_id = client.update_annotation(
 
 Update the maximum number of regions of a segmentation annotation.
 
-`max_area_count` is left unchanged when omitted. Set `None` to allow any number of regions.
+`max_area_count` accepts a value between 1 and 1000 and is left unchanged when omitted. Set `None`
+to allow any number of regions.
 
 ```python
 annotation_id = client.update_annotation(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -39,6 +39,20 @@ logging.basicConfig(
 )
 
 
+class _Unset:
+    """Marker for arguments the caller did not pass.
+
+    Needed where None is a meaningful value that has to be sent to the API,
+    and therefore cannot double as "leave this field untouched".
+    """
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+_UNSET = _Unset()
+
+
 class Client:
     api = None
 
@@ -4349,6 +4363,7 @@ class Client:
         color: str = None,
         order: int = None,
         attributes: list = [],
+        max_area_count: Union[int, None, _Unset] = _UNSET,
     ) -> str:
         """
         Update an annotation.
@@ -4358,6 +4373,10 @@ class Client:
         title is a display name of value (Optional).
         color is hex color code like #ffffff (Optional).
         attributes is a list of attribute (Optional).
+        max_area_count is the maximum number of separate regions a single
+        segmentation annotation may consist of, between 1 and 1000 (Optional).
+        It only applies to segmentation classes and is left unchanged when
+        omitted. Set None to allow any number of regions.
         """
         endpoint = "annotations/" + annotation_id
         payload = {}
@@ -4371,6 +4390,8 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
+        if not isinstance(max_area_count, _Unset):
+            payload["maxAreaCount"] = max_area_count
         return self.api.put_request(endpoint, payload=payload)
 
     def update_classification_annotation(

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -50,7 +50,9 @@ class _Unset:
         return "UNSET"
 
 
-_UNSET = _Unset()
+# Typed as Any so that the marker stays out of the public signatures that use it
+# as their default. Callers only ever pass an int or None.
+_UNSET: Any = _Unset()
 
 
 class Client:
@@ -4311,7 +4313,7 @@ class Client:
         color: str = None,
         order: int = None,
         attributes: list = [],
-        max_area_count: Union[int, None, _Unset] = _UNSET,
+        max_area_count: Optional[int] = _UNSET,
     ) -> str:
         """
         Create an annotation.
@@ -4365,7 +4367,7 @@ class Client:
         color: str = None,
         order: int = None,
         attributes: list = [],
-        max_area_count: Union[int, None, _Unset] = _UNSET,
+        max_area_count: Optional[int] = _UNSET,
     ) -> str:
         """
         Update an annotation.

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4311,7 +4311,7 @@ class Client:
         color: str = None,
         order: int = None,
         attributes: list = [],
-        max_area_count: Optional[int] = 1,
+        max_area_count: Union[int, None, _Unset] = _UNSET,
     ) -> str:
         """
         Create an annotation.
@@ -4325,8 +4325,9 @@ class Client:
         attributes is a list of attribute (Optional).
         max_area_count is the maximum number of separate regions a single
         segmentation annotation may consist of, between 1 and 1000 (Optional).
-        It only applies to segmentation classes and defaults to 1, which
-        disallows disjoint regions. Set None to allow any number of regions.
+        It only applies to segmentation classes. When omitted the API applies
+        its default of 1, which disallows disjoint regions. Set None to allow
+        any number of regions.
         """
         endpoint = "annotations"
         payload = {
@@ -4334,7 +4335,6 @@ class Client:
             "type": type,
             "value": value,
             "title": title,
-            "maxAreaCount": max_area_count,
         }
         if color:
             payload["color"] = color
@@ -4342,6 +4342,8 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
+        if not isinstance(max_area_count, _Unset):
+            payload["maxAreaCount"] = max_area_count
         return self.api.post_request(endpoint, payload=payload)
 
     def create_classification_annotation(self, project: str, attributes: list) -> str:

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4342,7 +4342,7 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        if not isinstance(max_area_count, _Unset):
+        if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.post_request(endpoint, payload=payload)
 
@@ -4392,7 +4392,7 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        if not isinstance(max_area_count, _Unset):
+        if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.put_request(endpoint, payload=payload)
 

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -40,18 +40,17 @@ logging.basicConfig(
 
 
 class _Unset:
-    """Marker for arguments the caller did not pass.
+    """呼び出し側が引数を渡さなかったことを表すマーカー。
 
-    Most optional arguments here have two states, and None covers the second
-    one: the field is either sent or left out. A few fields have three, because
-    null is one of the values the API acts on -- left out, sent as null, sent
-    as a value. For those, None is taken up by the null that has to reach the
-    API and cannot also mean "the caller said nothing", so this marker carries
-    that state instead and the argument is read by identity rather than truth.
+    このモジュールの任意引数は大半が「送る / 送らない」の二値で、後者を None
+    が兼ねられる。一方、null 自体が API へ送る意味のある値になる引数 (領域数
+    上限 maxAreaCount は 0 ではなく null が「無制限」を表す) は「省略 / null /
+    値」の三値になる。この場合 None は API へ届ける null の側に取られるため
+    「呼び出し側が何も言わなかった」を表せず、その状態をこのマーカーが担う。
+    引数は真偽ではなく同一性 (``is``) で判定する。
 
-    A single shared instance, so that the identity checks that read this marker
-    still hold after it has been copied or serialised on its way through
-    caller code.
+    インスタンスは 1 つだけ共有する。呼び出し側のコードで copy やシリアライズ
+    を経ても、このマーカーを読む同一性比較が壊れないようにするため。
     """
 
     _instance: Optional["_Unset"] = None
@@ -65,8 +64,8 @@ class _Unset:
         return "UNSET"
 
 
-# Typed as Any so that the marker stays out of the public signatures that use it
-# as their default. Callers only ever pass an int or None.
+# 既定値としてこのマーカーを使う関数の公開シグネチャに内部クラスが露出しない
+# よう Any で注釈する。呼び出し側が実際に渡すのは int か None のみ。
 _UNSET: Any = _Unset()
 
 
@@ -4359,9 +4358,10 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        # Three states, so the argument is read by identity: left out keeps the
-        # API's own default, None removes the limit, an int sets it. None is a
-        # value the API acts on and cannot also mean "not passed".
+        # maxAreaCount は API 側で「無制限」を null で表すため、None を渡すこと
+        # 自体が意味のある操作になる。他の任意引数のように None を「未指定」に
+        # 流用できず、省略 (API 既定値のまま) / None (無制限) / int (上限値) の
+        # 三値になるので、_UNSET との同一性比較で省略かどうかを見分ける。
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.post_request(endpoint, payload=payload)
@@ -4412,9 +4412,10 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        # Three states, so the argument is read by identity: left out keeps the
-        # stored value, None removes the limit, an int sets it. None is a value
-        # the API acts on and cannot also mean "not passed".
+        # maxAreaCount は API 側で「無制限」を null で表すため、None を渡すこと
+        # 自体が意味のある操作になる。他の任意引数のように None を「未指定」に
+        # 流用できず、省略 (保存済みの値のまま) / None (無制限) / int (上限値)
+        # の三値になるので、_UNSET との同一性比較で省略かどうかを見分ける。
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.put_request(endpoint, payload=payload)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -42,8 +42,12 @@ logging.basicConfig(
 class _Unset:
     """Marker for arguments the caller did not pass.
 
-    Needed where None is a meaningful value that has to be sent to the API,
-    and therefore cannot double as "leave this field untouched".
+    Most optional arguments here have two states, and None covers the second
+    one: the field is either sent or left out. A few fields have three, because
+    null is one of the values the API acts on -- left out, sent as null, sent
+    as a value. For those, None is taken up by the null that has to reach the
+    API and cannot also mean "the caller said nothing", so this marker carries
+    that state instead and the argument is read by identity rather than truth.
 
     A single shared instance, so that the identity checks that read this marker
     still hold after it has been copied or serialised on its way through
@@ -4355,6 +4359,9 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
+        # Three states, so the argument is read by identity: left out keeps the
+        # API's own default, None removes the limit, an int sets it. None is a
+        # value the API acts on and cannot also mean "not passed".
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.post_request(endpoint, payload=payload)
@@ -4405,6 +4412,9 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
+        # Three states, so the argument is read by identity: left out keeps the
+        # stored value, None removes the limit, an int sets it. None is a value
+        # the API acts on and cannot also mean "not passed".
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.put_request(endpoint, payload=payload)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -44,7 +44,18 @@ class _Unset:
 
     Needed where None is a meaningful value that has to be sent to the API,
     and therefore cannot double as "leave this field untouched".
+
+    A single shared instance, so that the identity checks that read this marker
+    still hold after it has been copied or serialised on its way through
+    caller code.
     """
+
+    _instance: Optional["_Unset"] = None
+
+    def __new__(cls) -> "_Unset":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
 
     def __repr__(self) -> str:
         return "UNSET"

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -40,17 +40,19 @@ logging.basicConfig(
 
 
 class _Unset:
-    """呼び出し側が引数を渡さなかったことを表すマーカー。
+    """Marker for arguments the caller did not pass.
 
-    このモジュールの任意引数は大半が「送る / 送らない」の二値で、後者を None
-    が兼ねられる。一方、null 自体が API へ送る意味のある値になる引数 (領域数
-    上限 maxAreaCount は 0 ではなく null が「無制限」を表す) は「省略 / null /
-    値」の三値になる。この場合 None は API へ届ける null の側に取られるため
-    「呼び出し側が何も言わなかった」を表せず、その状態をこのマーカーが担う。
-    引数は真偽ではなく同一性 (``is``) で判定する。
+    Most optional arguments here have two states and None covers the second
+    one: the field is either sent or left out. maxAreaCount has three, because
+    the API represents "unlimited" as null rather than as 0, so null is itself
+    a value that has to reach the API -- left out, sent as null, sent as a
+    number. None is taken up by that null and cannot also mean "the caller
+    said nothing", so this marker carries that state instead and the argument
+    is read by identity rather than by truthiness.
 
-    インスタンスは 1 つだけ共有する。呼び出し側のコードで copy やシリアライズ
-    を経ても、このマーカーを読む同一性比較が壊れないようにするため。
+    A single shared instance, so that the identity checks that read this
+    marker still hold after it has been copied or serialised on its way
+    through caller code.
     """
 
     _instance: Optional["_Unset"] = None
@@ -64,8 +66,8 @@ class _Unset:
         return "UNSET"
 
 
-# 既定値としてこのマーカーを使う関数の公開シグネチャに内部クラスが露出しない
-# よう Any で注釈する。呼び出し側が実際に渡すのは int か None のみ。
+# Typed as Any so that the marker stays out of the public signatures that use it
+# as their default. Callers only ever pass an int or None.
 _UNSET: Any = _Unset()
 
 
@@ -4358,10 +4360,11 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        # maxAreaCount は API 側で「無制限」を null で表すため、None を渡すこと
-        # 自体が意味のある操作になる。他の任意引数のように None を「未指定」に
-        # 流用できず、省略 (API 既定値のまま) / None (無制限) / int (上限値) の
-        # 三値になるので、_UNSET との同一性比較で省略かどうかを見分ける。
+        # maxAreaCount represents "unlimited" as null rather than as 0, so
+        # passing None is itself a meaningful call and None cannot double as
+        # "not passed" the way it does for the other optional arguments. The
+        # three states are read by identity: left out keeps the API's default,
+        # None removes the limit, an int sets it.
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.post_request(endpoint, payload=payload)
@@ -4412,10 +4415,11 @@ class Client:
             payload["order"] = order
         if attributes:
             payload["attributes"] = attributes
-        # maxAreaCount は API 側で「無制限」を null で表すため、None を渡すこと
-        # 自体が意味のある操作になる。他の任意引数のように None を「未指定」に
-        # 流用できず、省略 (保存済みの値のまま) / None (無制限) / int (上限値)
-        # の三値になるので、_UNSET との同一性比較で省略かどうかを見分ける。
+        # maxAreaCount represents "unlimited" as null rather than as 0, so
+        # passing None is itself a meaningful call and None cannot double as
+        # "not passed" the way it does for the other optional arguments. The
+        # three states are read by identity: left out keeps the stored value,
+        # None removes the limit, an int sets it.
         if max_area_count is not _UNSET:
             payload["maxAreaCount"] = max_area_count
         return self.api.put_request(endpoint, payload=payload)

--- a/fastlabel/__init__.py
+++ b/fastlabel/__init__.py
@@ -4297,6 +4297,7 @@ class Client:
         color: str = None,
         order: int = None,
         attributes: list = [],
+        max_area_count: Optional[int] = 1,
     ) -> str:
         """
         Create an annotation.
@@ -4308,6 +4309,10 @@ class Client:
         title is a display name of value (Required).
         color is hex color code like #ffffff (Optional).
         attributes is a list of attribute (Optional).
+        max_area_count is the maximum number of separate regions a single
+        segmentation annotation may consist of, between 1 and 1000 (Optional).
+        It only applies to segmentation classes and defaults to 1, which
+        disallows disjoint regions. Set None to allow any number of regions.
         """
         endpoint = "annotations"
         payload = {
@@ -4315,6 +4320,7 @@ class Client:
             "type": type,
             "value": value,
             "title": title,
+            "maxAreaCount": max_area_count,
         }
         if color:
             payload["color"] = color

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import cv2
 import numpy as np
 import pytest
 
+import fastlabel
+
 
 def _write_synthetic_video(
     path: Path,
@@ -46,5 +48,28 @@ def synthetic_video(tmp_path):
             fps=fps,
             fourcc_code=fourcc_code,
         )
+
+    return _factory
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("FASTLABEL_ACCESS_TOKEN", "dummy-token")
+    return fastlabel.Client()
+
+
+@pytest.fixture
+def capture_request(monkeypatch):
+    """Replace an api.*_request method with a recorder and return the calls list."""
+
+    def _factory(client, method_name, return_value=None):
+        calls = []
+
+        def fake(endpoint, *args, **kwargs):
+            calls.append({"endpoint": endpoint, "args": args, "kwargs": kwargs})
+            return return_value
+
+        monkeypatch.setattr(client.api, method_name, fake)
+        return calls
 
     return _factory

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -5,34 +5,11 @@ endpoint and payload, with a focus on max_area_count. The HTTP layer
 (client.api.*_request) is stubbed so no real request is made.
 """
 
-import pytest
-
-import fastlabel
-
-
-@pytest.fixture
-def client(monkeypatch):
-    monkeypatch.setenv("FASTLABEL_ACCESS_TOKEN", "dummy-token")
-    return fastlabel.Client()
-
-
-def _capture(monkeypatch, client, method_name, return_value=None):
-    """Replace an api.*_request method with a recorder and return the calls list."""
-    calls = []
-
-    def fake(endpoint, *args, **kwargs):
-        calls.append({"endpoint": endpoint, "args": args, "kwargs": kwargs})
-        return return_value
-
-    monkeypatch.setattr(client.api, method_name, fake)
-    return calls
-
-
 # --- create_annotation -----------------------------------------------------
 
 
-def test_create_annotation_omits_max_area_count_by_default(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+def test_create_annotation_omits_max_area_count_by_default(client, capture_request):
+    calls = capture_request(client, "post_request", return_value="anno-id")
 
     client.create_annotation(
         project="my-project", type="segmentation", value="cat", title="Cat"
@@ -48,8 +25,8 @@ def test_create_annotation_omits_max_area_count_by_default(monkeypatch, client):
     }
 
 
-def test_create_annotation_with_max_area_count(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+def test_create_annotation_with_max_area_count(client, capture_request):
+    calls = capture_request(client, "post_request", return_value="anno-id")
 
     client.create_annotation(
         project="my-project",
@@ -62,8 +39,8 @@ def test_create_annotation_with_max_area_count(monkeypatch, client):
     assert calls[0]["kwargs"]["payload"]["maxAreaCount"] == 10
 
 
-def test_create_annotation_without_max_area_count_limit(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+def test_create_annotation_without_max_area_count_limit(client, capture_request):
+    calls = capture_request(client, "post_request", return_value="anno-id")
 
     client.create_annotation(
         project="my-project",
@@ -80,8 +57,8 @@ def test_create_annotation_without_max_area_count_limit(monkeypatch, client):
 # --- update_annotation -----------------------------------------------------
 
 
-def test_update_annotation_omits_max_area_count_by_default(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+def test_update_annotation_omits_max_area_count_by_default(client, capture_request):
+    calls = capture_request(client, "put_request", return_value="anno-id")
 
     client.update_annotation(annotation_id="anno-id", title="Cat")
 
@@ -89,16 +66,16 @@ def test_update_annotation_omits_max_area_count_by_default(monkeypatch, client):
     assert calls[0]["kwargs"]["payload"] == {"title": "Cat"}
 
 
-def test_update_annotation_with_max_area_count(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+def test_update_annotation_with_max_area_count(client, capture_request):
+    calls = capture_request(client, "put_request", return_value="anno-id")
 
     client.update_annotation(annotation_id="anno-id", max_area_count=10)
 
     assert calls[0]["kwargs"]["payload"] == {"maxAreaCount": 10}
 
 
-def test_update_annotation_without_max_area_count_limit(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+def test_update_annotation_without_max_area_count_limit(client, capture_request):
+    calls = capture_request(client, "put_request", return_value="anno-id")
 
     client.update_annotation(annotation_id="anno-id", max_area_count=None)
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -5,6 +5,13 @@ endpoint and payload, with a focus on max_area_count. The HTTP layer
 (client.api.*_request) is stubbed so no real request is made.
 """
 
+import copy
+import pickle
+
+import pytest
+
+import fastlabel
+
 # --- create_annotation -----------------------------------------------------
 
 
@@ -81,3 +88,32 @@ def test_update_annotation_without_max_area_count_limit(client, capture_request)
 
     # None is sent as an explicit null, which means no limit on the server side
     assert calls[0]["kwargs"]["payload"] == {"maxAreaCount": None}
+
+
+# --- the "not passed" marker -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "round_trip",
+    [copy.deepcopy, lambda value: pickle.loads(pickle.dumps(value))],
+    ids=["deepcopy", "pickle"],
+)
+def test_create_annotation_keeps_marker_meaning_after_round_trip(
+    client, capture_request, round_trip
+):
+    calls = capture_request(client, "post_request", return_value="anno-id")
+
+    # Callers that collect keyword arguments and pass them around must still
+    # get "omitted" out of the default, which relies on the marker's identity
+    kwargs = round_trip(
+        {
+            "project": "my-project",
+            "type": "segmentation",
+            "value": "cat",
+            "title": "Cat",
+            "max_area_count": fastlabel._UNSET,
+        }
+    )
+    client.create_annotation(**kwargs)
+
+    assert "maxAreaCount" not in calls[0]["kwargs"]["payload"]

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,77 @@
+"""Tests for the annotation class API client methods.
+
+These verify that create_annotation builds the correct endpoint and payload,
+with a focus on max_area_count. The HTTP layer (client.api.*_request) is
+stubbed so no real request is made.
+"""
+
+import pytest
+
+import fastlabel
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("FASTLABEL_ACCESS_TOKEN", "dummy-token")
+    return fastlabel.Client()
+
+
+def _capture(monkeypatch, client, method_name, return_value=None):
+    """Replace an api.*_request method with a recorder and return the calls list."""
+    calls = []
+
+    def fake(endpoint, *args, **kwargs):
+        calls.append({"endpoint": endpoint, "args": args, "kwargs": kwargs})
+        return return_value
+
+    monkeypatch.setattr(client.api, method_name, fake)
+    return calls
+
+
+# --- create_annotation -----------------------------------------------------
+
+
+def test_create_annotation_defaults_max_area_count_to_one(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+
+    client.create_annotation(
+        project="my-project", type="segmentation", value="cat", title="Cat"
+    )
+
+    assert calls[0]["endpoint"] == "annotations"
+    assert calls[0]["kwargs"]["payload"] == {
+        "project": "my-project",
+        "type": "segmentation",
+        "value": "cat",
+        "title": "Cat",
+        "maxAreaCount": 1,
+    }
+
+
+def test_create_annotation_with_max_area_count(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+
+    client.create_annotation(
+        project="my-project",
+        type="segmentation",
+        value="cat",
+        title="Cat",
+        max_area_count=10,
+    )
+
+    assert calls[0]["kwargs"]["payload"]["maxAreaCount"] == 10
+
+
+def test_create_annotation_without_max_area_count_limit(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
+
+    client.create_annotation(
+        project="my-project",
+        type="segmentation",
+        value="cat",
+        title="Cat",
+        max_area_count=None,
+    )
+
+    # None is sent as an explicit null, which means no limit on the server side
+    assert calls[0]["kwargs"]["payload"]["maxAreaCount"] is None

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,8 +1,8 @@
 """Tests for the annotation class API client methods.
 
-These verify that create_annotation builds the correct endpoint and payload,
-with a focus on max_area_count. The HTTP layer (client.api.*_request) is
-stubbed so no real request is made.
+These verify that create_annotation and update_annotation build the correct
+endpoint and payload, with a focus on max_area_count. The HTTP layer
+(client.api.*_request) is stubbed so no real request is made.
 """
 
 import pytest
@@ -75,3 +75,32 @@ def test_create_annotation_without_max_area_count_limit(monkeypatch, client):
 
     # None is sent as an explicit null, which means no limit on the server side
     assert calls[0]["kwargs"]["payload"]["maxAreaCount"] is None
+
+
+# --- update_annotation -----------------------------------------------------
+
+
+def test_update_annotation_omits_max_area_count_by_default(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+
+    client.update_annotation(annotation_id="anno-id", title="Cat")
+
+    assert calls[0]["endpoint"] == "annotations/anno-id"
+    assert calls[0]["kwargs"]["payload"] == {"title": "Cat"}
+
+
+def test_update_annotation_with_max_area_count(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+
+    client.update_annotation(annotation_id="anno-id", max_area_count=10)
+
+    assert calls[0]["kwargs"]["payload"] == {"maxAreaCount": 10}
+
+
+def test_update_annotation_without_max_area_count_limit(monkeypatch, client):
+    calls = _capture(monkeypatch, client, "put_request", return_value="anno-id")
+
+    client.update_annotation(annotation_id="anno-id", max_area_count=None)
+
+    # None is sent as an explicit null, which means no limit on the server side
+    assert calls[0]["kwargs"]["payload"] == {"maxAreaCount": None}

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -31,20 +31,20 @@ def _capture(monkeypatch, client, method_name, return_value=None):
 # --- create_annotation -----------------------------------------------------
 
 
-def test_create_annotation_defaults_max_area_count_to_one(monkeypatch, client):
+def test_create_annotation_omits_max_area_count_by_default(monkeypatch, client):
     calls = _capture(monkeypatch, client, "post_request", return_value="anno-id")
 
     client.create_annotation(
         project="my-project", type="segmentation", value="cat", title="Cat"
     )
 
+    # The field is left out entirely so the API applies its own default of 1
     assert calls[0]["endpoint"] == "annotations"
     assert calls[0]["kwargs"]["payload"] == {
         "project": "my-project",
         "type": "segmentation",
         "value": "cat",
         "title": "Cat",
-        "maxAreaCount": 1,
     }
 
 

--- a/tests/test_workspace_user.py
+++ b/tests/test_workspace_user.py
@@ -9,30 +9,11 @@ import pytest
 
 import fastlabel
 
-
-@pytest.fixture
-def client(monkeypatch):
-    monkeypatch.setenv("FASTLABEL_ACCESS_TOKEN", "dummy-token")
-    return fastlabel.Client()
-
-
-def _capture(monkeypatch, client, method_name, return_value=None):
-    """Replace an api.*_request method with a recorder and return the calls list."""
-    calls = []
-
-    def fake(endpoint, *args, **kwargs):
-        calls.append({"endpoint": endpoint, "args": args, "kwargs": kwargs})
-        return return_value
-
-    monkeypatch.setattr(client.api, method_name, fake)
-    return calls
-
-
 # --- get_workspace_users ---------------------------------------------------
 
 
-def test_get_workspace_users_default(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "get_request", return_value=[])
+def test_get_workspace_users_default(client, capture_request):
+    calls = capture_request(client, "get_request", return_value=[])
 
     client.get_workspace_users()
 
@@ -41,8 +22,8 @@ def test_get_workspace_users_default(monkeypatch, client):
     assert calls[0]["kwargs"]["params"] == {"limit": 20}
 
 
-def test_get_workspace_users_with_params(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "get_request", return_value=[])
+def test_get_workspace_users_with_params(client, capture_request):
+    calls = capture_request(client, "get_request", return_value=[])
 
     client.get_workspace_users(keyword="john", offset=10, limit=50)
 
@@ -53,8 +34,8 @@ def test_get_workspace_users_with_params(monkeypatch, client):
     }
 
 
-def test_get_workspace_users_offset_zero_included(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "get_request", return_value=[])
+def test_get_workspace_users_offset_zero_included(client, capture_request):
+    calls = capture_request(client, "get_request", return_value=[])
 
     client.get_workspace_users(offset=0)
 
@@ -65,8 +46,8 @@ def test_get_workspace_users_offset_zero_included(monkeypatch, client):
 # --- create_workspace_user -------------------------------------------------
 
 
-def test_create_workspace_user_without_modules(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "post_request", return_value={})
+def test_create_workspace_user_without_modules(client, capture_request):
+    calls = capture_request(client, "post_request", return_value={})
 
     client.create_workspace_user(
         name="John Doe",
@@ -87,8 +68,8 @@ def test_create_workspace_user_without_modules(monkeypatch, client):
 # --- update_workspace_user -------------------------------------------------
 
 
-def test_update_workspace_user_role(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "put_request", return_value={})
+def test_update_workspace_user_role(client, capture_request):
+    calls = capture_request(client, "put_request", return_value={})
 
     client.update_workspace_user(email="john@example.com", role="owner")
 
@@ -102,9 +83,9 @@ def test_update_workspace_user_role(monkeypatch, client):
 # --- delete_workspace_user -------------------------------------------------
 
 
-def test_delete_workspace_user(monkeypatch, client):
+def test_delete_workspace_user(client, capture_request):
     # deletion is performed via PUT with role='none' (no DELETE endpoint)
-    calls = _capture(monkeypatch, client, "put_request", return_value=None)
+    calls = capture_request(client, "put_request", return_value=None)
 
     result = client.delete_workspace_user(email="john@example.com")
 
@@ -127,8 +108,10 @@ def test_delete_workspace_user(monkeypatch, client):
         ("modelDev", "function-resource-permissions/model-dev/internal-users"),
     ],
 )
-def test_create_module_permissions_single(monkeypatch, client, module, expected_path):
-    calls = _capture(monkeypatch, client, "post_request", return_value=module)
+def test_create_module_permissions_single(
+    client, capture_request, module, expected_path
+):
+    calls = capture_request(client, "post_request", return_value=module)
 
     # a single module string is accepted (not only a list)
     result = client.create_workspace_user_module_permissions(
@@ -141,8 +124,8 @@ def test_create_module_permissions_single(monkeypatch, client, module, expected_
     assert result == [module]
 
 
-def test_create_module_permissions_multiple(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "post_request", return_value="ok")
+def test_create_module_permissions_multiple(client, capture_request):
+    calls = capture_request(client, "post_request", return_value="ok")
 
     result = client.create_workspace_user_module_permissions(
         email="john@example.com", modules=["annotation", "dataset"]
@@ -156,8 +139,8 @@ def test_create_module_permissions_multiple(monkeypatch, client):
     assert result == ["ok", "ok"]
 
 
-def test_create_module_permissions_invalid_module(monkeypatch, client):
-    _capture(monkeypatch, client, "post_request", return_value=None)
+def test_create_module_permissions_invalid_module(client, capture_request):
+    capture_request(client, "post_request", return_value=None)
 
     with pytest.raises(fastlabel.exceptions.FastLabelInvalidException):
         client.create_workspace_user_module_permissions(
@@ -168,8 +151,8 @@ def test_create_module_permissions_invalid_module(monkeypatch, client):
 # --- delete_workspace_user_module_permissions ------------------------------
 
 
-def test_delete_module_permissions_single(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "delete_request", return_value=None)
+def test_delete_module_permissions_single(client, capture_request):
+    calls = capture_request(client, "delete_request", return_value=None)
 
     client.delete_workspace_user_module_permissions(
         email="john@example.com", modules="modelDev"
@@ -183,8 +166,8 @@ def test_delete_module_permissions_single(monkeypatch, client):
     }
 
 
-def test_delete_module_permissions_multiple(monkeypatch, client):
-    calls = _capture(monkeypatch, client, "delete_request", return_value=None)
+def test_delete_module_permissions_multiple(client, capture_request):
+    calls = capture_request(client, "delete_request", return_value=None)
 
     client.delete_workspace_user_module_permissions(
         email="john@example.com", modules=["annotation", "modelDev"]
@@ -197,8 +180,8 @@ def test_delete_module_permissions_multiple(monkeypatch, client):
     assert all(c["endpoint"] == "function-resource-permissions" for c in calls)
 
 
-def test_delete_module_permissions_invalid_module(monkeypatch, client):
-    _capture(monkeypatch, client, "delete_request", return_value=None)
+def test_delete_module_permissions_invalid_module(client, capture_request):
+    capture_request(client, "delete_request", return_value=None)
 
     with pytest.raises(fastlabel.exceptions.FastLabelInvalidException):
         client.delete_workspace_user_module_permissions(


### PR DESCRIPTION
## 概要

アノテーションクラスの「1アノテーションあたりの領域数上限」（`maxAreaCount`）を、SDKから指定・変更できるようにしました。

これまでSDKでアノテーションクラスを作成すると、この値がAPI側で常に `1` に固定されていました。`1` だと飛び地のセグメンテーションができないため、SDKでクラスを同期している案件では、作成後に画面から1クラスずつ「なし」に直す必要がありました。更新メソッドでも変更できず、既存クラスをまとめて直す手段もありませんでした。

省略時の値は従来どおり `1` です（API側の既定値）。既存の連携の振る舞いが変わらないようにするためです。

## 対応内容

- `create_annotation` に `max_area_count` を追加。省略時はリクエストに含めず、API側の既定値 `1` に委ねる。`None` を指定すると「なし」（無制限）、整数を指定するとその値
- `update_annotation` に `max_area_count` を追加。省略時はリクエストに含めないため変更されず、`None` を指定すると「なし」（無制限）
- 既存の引数の並びは変えず、いずれも末尾に追加しています
- READMEに使用例と有効範囲（1〜1000）を追記

作成・更新のどちらも「引数を渡さなかった」と「`None` を渡した」を区別する必要があります。`None` は「上限なし」という意味でAPIへ送る値なので、「未指定」の意味を兼ねられません。そのためモジュール内にセンチネル `_UNSET` を置き、それ以外が渡されたときだけ `maxAreaCount` をリクエストに載せています。センチネルの型注釈は `Any` にして、公開されるシグネチャが `Optional[int]` のままになるようにしています。

有効範囲（1〜1000）と整数かどうかの検証はAPI側に委ねています（422が返ります）。同じ `Client` に `limit` などをクライアント側で弾く例はありますが、上限値をリポジトリを跨いで二重に持たないほうがよいと判断しました。

### テスト

- `tests/test_annotation.py` を追加。作成・更新それぞれで、省略時にキーを送らないこと、`None` と整数がそのまま載ることを検証
- テスト用の `client` fixture とリクエスト記録ヘルパーを `tests/conftest.py` へ移動。`tests/test_workspace_user.py` に同じものが定義されていたため、そちらも共有fixtureを使う形に書き換えています（振る舞いの変更はありません）

## 依存

API側の対応（fastlabel/fastlabel-application#11670）のリリース後に、このPRをマージ・リリースしてください。`max_area_count` を指定したときだけAPI側の対応が必要で、指定しない既存の呼び出しはリクエスト内容が従来と同一のため、API側のリリース前でも影響ありません。

- fastlabel/fastlabel-application#11670
- fastlabel/fastlabel-application#11669

## 動作確認

```bash
pytest tests/            # 20 passed
black --check . && flake8 . && isort --check .
```

CIはlintとPython 3.10〜3.14のマトリクスが全てpassしています。

あわせて、ローカル環境のAPI（#11670 のブランチのコード）に対してこのSDKから実際にリクエストを投げ、作成（省略時 `1` / `None` / 整数 / 境界値 / 範囲外は422）、更新（省略時は変更なし / `None` / 整数 / 範囲外は422で既存値も変わらない）、読み出し、`max_area_count` を渡さない従来どおりの呼び出しを確認しています。
